### PR TITLE
Fix grid after overflow scroll added to nav

### DIFF
--- a/css/doc_site_styling.scss
+++ b/css/doc_site_styling.scss
@@ -21,6 +21,7 @@ body {
   width: 100vw;
   display: grid;
   grid-template-columns: min-content auto;
+  grid-template-rows: min-content 1fr min-content;
   grid-template-areas:
     "header header"
     "sidebar content"


### PR DESCRIPTION
#### What does this PR do?
- Sets up `grid-template-rows`

#### Where should the reviewer start?


#### How should this be manually tested?
pull the PR and test on `Home` and `Borders`, resize the page to be full screen are smaller and make sure everything is in the correct spots and you can scroll the nav and the main content

#### Any background context you want to provide?
I added a bug when I put in `overflow-y: scroll;` on `.main-nav` as it wasn't needed yet. This messed up the layout on pages where the main content wasn't filling up the page

#### What are the relevant tickets?
https://3.basecamp.com/3494409/buckets/19192671/todos/3314929181

#### Screenshots (if appropriate)

##### BEFORE 
<img width="1680" alt="Screen Shot 2021-02-08 at 5 03 00 PM" src="https://user-images.githubusercontent.com/1551316/107296901-84442e00-6a2f-11eb-8f66-dd0dcf1cb04c.png">

##### AFTER
<img width="1680" alt="Screen Shot 2021-02-08 at 5 06 29 PM" src="https://user-images.githubusercontent.com/1551316/107297164-003e7600-6a30-11eb-8804-507bd1302ffe.png">

#### Any other deploy steps?
nope