### PR TITLE
Improve font family declarations

### DIFF
--- a/css/design_system/components/nav.scss
+++ b/css/design_system/components/nav.scss
@@ -15,8 +15,7 @@
  * </nav>
  */
 .nav {
-  font-family: 'Helvetica Neue Bold';
-  font-weight: var(--font-weight-bold);
+  font-weight: var(--s-font-weight-bold);
   height: var(--nav-height);
   position: sticky;
   width: 100%;

--- a/css/design_system/elements/button.scss
+++ b/css/design_system/elements/button.scss
@@ -10,6 +10,7 @@
  * </button>
  */
 .button {
+  font-weight: var(--s-font-weight-heavy);
   border: none;
   border-radius: 50px;
   font-size: 14px;

--- a/css/design_system/tokens/fonts.scss
+++ b/css/design_system/tokens/fonts.scss
@@ -1,88 +1,100 @@
 :root {
-  --font-weight-heavy: 900;
-  --font-weight-bold: 700;
-  --font-weight-normal: 400;
-  --font-weight-light: 300;
-  --font-weight-ultra-light: 200;
+  --s-font-weight-heavy: 900;
+  --s-font-weight-bold: 700;
+  --s-font-weight-normal: 400;
+  --s-font-weight-light: 300;
+  --s-font-weight-ultra-light: 200;
 
   /**
-   * @title --font-family-default
-   * @value Helvetica Neue Normal
+   * @title --s-font-family-default
+   * @value Helvetica Neue
    * Default Font Family
    */
-  --font-family-default: "Helvetica Neue Normal", sans-serif;
+  --s-font-family-default: "Helvetica Neue", Helvetica, sans-serif;
 
   /**
-   * @title --font-family-alternate
+   * @title --s-font-family-alternate
    * @value Roboto Slab
    * Alternate Font Family
    */
-  --font-family-alternate: "Roboto Slab", sans-serif;
+  --s-font-family-alternate: "Roboto Slab", sans-serif;
 
   /**
-   * @title --font-family-mono
+   * @title --s-font-family-mono
    * @value Roboto Mono
    * Monospace Font Family
    */
-  --font-family-mono: "Roboto Mono", monospace;
+  --s-font-family-mono: "Roboto Mono", monospace;
 }
 
-@font-face {
-  font-family: "Helvetica Neue Heavy";
-  font-weight: var(--font-weight-heavy);
-  src: url("/assets/fonts/HelveticaNeueLTStd-Hv.otf");
-}
+/* NOTE: we use the literal font-weight values in all @font-face declarations b/c using var() breaks the dynamic font loading */
 
 @font-face {
-  font-family: "Helvetica Neue Bold";
-  font-weight: var(--font-weight-bold);
-  src: url("/assets/fonts/HelveticaNeueLTStd-Bd.otf");
-}
-
-@font-face {
-  font-family: "Helvetica Neue Normal";
-  font-weight: var(--font-weight-normal);
-  src: url("/assets/fonts/HelveticaNeueLTStd-Lt.otf");
-}
-
-@font-face {
-  font-family: "Helvetica Neue Light";
-  font-weight: var(--font-weight-light);
-  src: url("/assets/fonts/HelveticaNeueLTStd-Th.otf");
-}
-
-@font-face {
-  font-family: "Helvetica Neue Ultra Light";
-  font-weight: var(--font-weight-ultra-light);
+  font-family: "Helvetica Neue";
   src: url("/assets/fonts/HelveticaNeueLtStd-UltLt.otf");
+  font-style: normal;
+  font-weight: 200;
 }
 
 @font-face {
-  font-family: "Roboto Slab Normal";
-  font-weight: var(--font-weight-normal);
-  src: url("/assets/fonts/RobotoSlab-Regular.ttf");
+  font-family: "Helvetica Neue";
+  src: url("/assets/fonts/HelveticaNeueLTStd-Th.otf");
+  font-style: normal;
+  font-weight: 300;
 }
 
 @font-face {
-  font-family: "Roboto Slab Light";
-  font-weight: var(--font-weight-light);
+  font-family: "Helvetica Neue";
+  src: url("/assets/fonts/HelveticaNeueLTStd-Lt.otf");
+  font-style: normal;
+  font-weight: 400;
+}
+
+@font-face {
+  font-family: "Helvetica Neue";
+  src: url("/assets/fonts/HelveticaNeueLTStd-Bd.otf");
+  font-style: normal;
+  font-weight: 700;
+}
+
+@font-face {
+  font-family: "Helvetica Neue";
+  src: url("/assets/fonts/HelveticaNeueLTStd-Hv.otf");
+  font-style: normal;
+  font-weight: 900;
+}
+
+@font-face {
+  font-family: "Roboto Slab";
   src: url("/assets/fonts/RobotoSlab-Light.ttf");
+  font-style: normal;
+  font-weight: 300;
 }
 
 @font-face {
-  font-family: "Roboto Mono Light";
-  font-weight: var(--font-weight-light);
+  font-family: "Roboto Slab";
+  src: url("/assets/fonts/RobotoSlab-Regular.ttf");
+  font-style: normal;
+  font-weight: 400;
+}
+
+@font-face {
+  font-family: "Roboto Mono";
   src: url("/assets/fonts/RobotoMono-Light.ttf");
+  font-style: normal;
+  font-weight: 300;
 }
 
 @font-face {
-  font-family: "Roboto Mono Normal";
-  font-weight: var(--font-weight-normal);
+  font-family: "Roboto Mono";
   src: url("/assets/fonts/RobotoMono-Normal.ttf");
+  font-style: normal;
+  font-weight: 400;
 }
 
 @font-face {
-  font-family: "Roboto Mono Bold";
-  font-weight: var(--font-weight-bold);
+  font-family: "Roboto Mono";
   src: url("/assets/fonts/RobotoMono-Medium.ttf");
+  font-style: normal;
+  font-weight: 700;
 }

--- a/css/doc_site_styling.scss
+++ b/css/doc_site_styling.scss
@@ -7,7 +7,8 @@
 
 body {
   background-color: var(--s-color-white);
-  font-family: Helvetica Neue Normal;
+  font-family:  var(--s-font-family-default);
+  font-weight: var(--s-font-weight-normal);
   color: var(--s-color-gray-700);
   overflow: hidden;
 }
@@ -114,7 +115,8 @@ body {
   flex-wrap: wrap;
   flex-direction: row;
   min-width: 300px;
-  font-family: "Helvetica Neue Bold";
+  font-family: var(--s-font-family-default);
+  font-weight: var(--s-font-weight-bold);
   background-color: var(--s-color-gray-100);
   text-transform: uppercase;
   overflow-y: scroll;

--- a/docs/_tokens/--font-family-default.md
+++ b/docs/_tokens/--font-family-default.md
@@ -1,7 +1,0 @@
----
-title: "--font-family-default"
-value: |-
-  Helvetica Neue Normal
-  Default Font Family
-order: 1
----

--- a/docs/_tokens/--s-font-family-alternate.md
+++ b/docs/_tokens/--s-font-family-alternate.md
@@ -1,5 +1,5 @@
 ---
-title: "--font-family-alternate"
+title: "--s-font-family-alternate"
 value: |-
   Roboto Slab
   Alternate Font Family

--- a/docs/_tokens/--s-font-family-default.md
+++ b/docs/_tokens/--s-font-family-default.md
@@ -1,0 +1,7 @@
+---
+title: "--s-font-family-default"
+value: |-
+  Helvetica Neue
+  Default Font Family
+order: 1
+---

--- a/docs/_tokens/--s-font-family-mono.md
+++ b/docs/_tokens/--s-font-family-mono.md
@@ -1,5 +1,5 @@
 ---
-title: "--font-family-mono"
+title: "--s-font-family-mono"
 value: |-
   Roboto Mono
   Monospace Font Family

--- a/typography.html
+++ b/typography.html
@@ -6,7 +6,7 @@ permalink: /typography/
 
 <table class="token-table">
   {% for token in site.tokens %}
-    {% if token.title contains "--font" %}
+    {% if token.title contains "--s-font" %}
       <tr class="token-table-row">
         <td class="token-title-description-cell">
           <code>{{ token.title }}</code>


### PR DESCRIPTION
#### What does this PR do?

- Use style linking to enable multiple variants of same font family
- Update token names for fonts (use `--s-` prefix)
- Fix problem where using variables in @font-face declarations was
  breaking the style linking
- Update docs

Before, we had to specify different font-families when we wanted to use a variant like bold or italic, e.g.:

```scss
.my-class {
  font-family: "Helvetica Neue Bold";
}
```

Now, we can use a single font family and use the more intuitive font-weight (and eventually, font-style) properties:

```scss
.my-class {
  font-family: "Helvetica Neue";
  font-weight: var(--s-font-weight-bold);
}
```

#### Where should the reviewer start?

fonts.scss

#### How should this be manually tested?

COnf

#### Any background context you want to provide?

Helpful resources we used to make these changes:

- https://www.smashingmagazine.com/2013/02/setting-weights-and-styles-at-font-face-declaration/
- https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face
- https://css-tricks.com/snippets/css/using-font-face/


#### What are the relevant tickets?

:basecamp: [Figure out font stuff before we can go on - table for Hackathon day](https://3.basecamp.com/3494409/buckets/19192671/todos/3501119368)

#### Screenshots (if appropriate)


#### Any other deploy steps?
no