### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To set the project up locally on your machine:
 
 Please follow Turing's shared [How to Contribute](https://www.notion.so/turingschool/How-to-Contribute-1b88e17f755c491989e4b2bc84db93c7) guide.
 
-Anything that is merged into the `main` branch will be immediately available on the `latest` version, which has been communicated to users that it may not be stable. If you'd like your changes to be on a new version, make sure to follow the guidance outlined in [contributing.md](./contributing.md).
+Anything that is merged into the `main` branch will not be immediately available on the `latest` version (or any other version). To release a new version and publish the latest changes, make sure to follow the guidance outlined in [contributing.md](./contributing.md).
 
 ## How To: Add a Token, Element or Component
 
@@ -56,16 +56,16 @@ The workflow to add a token, element or component to Savile is as follows:
 
     ```css
     /**
-    * @title Base Button
-    * @category elements
-    * @element_type button
-    * @status draft
-    * @value s-button
-    * @description Our base button styles. Any other button class can be used in addition to this, to get the desired variant.
-    *
-    * @example
-    * <button class="s-button">Base Button</button>
-    */
+     * @title Base Button
+     * @category elements
+     * @element_type button
+     * @status draft
+     * @value s-button
+     * @description Our base button styles. Any other button class can be used in addition to this, to get the desired variant.
+     *
+     * @example
+     * <button class="s-button">Base Button</button>
+     */
     ```
 
 - In your terminal, run `ruby build_css_docs.rb` to run the generator, which will take the single SCSS file you created and wrote, and both feed the CSS into the design system (`_site/css`), and take the documentation and make it markdown-friendly (`docs`).
@@ -81,7 +81,7 @@ If changes are made to the S3 bucket (add/remove files), then you can update the
 $ ruby ./build_assets_data.rb
 ```
 
-If you'd like to add to or update the assets in the S3 bucket and don't have access, please contact @Tanner on Slack.
+If you'd like to add to or update the assets in the S3 bucket and don't have access, please post a message in the #fancy-boots channel on Slack.
 
 ## Terminology
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ More information about internal engineering @ Turing is available on [Turing's E
 - [Local Set Up](#local-set-up)
 - [Contributing](#contributing)
 - [How To: Add a Token, Element or Component](#how-to-add-a-token-element-or-component)
+- [How To: Update the Assets Page](#how-to-update-the-assets-page)
 - [Terminology](#terminology)
 
 ## Savile Guiding Principles
@@ -22,8 +23,8 @@ While we have Guiding Principles for our overarching work on the Turing Engineer
 - **Simple.** This is a lightweight package in term of size. It is conceptually simple and straightforward; intuitive naming and reasonable variants. A developer should be able to read through our docs and in a couple hours have a good handle on how it works and how to utilize it.
 - **Extensible.** It is built in a way that various team members can build on top of it relatively easily. Ways to override and customize are available and documented.
 - **Durable.** The current form will last and continue to work, for all users and all app, regardless of tech stack.
-- **Composable.** - Utils and variants can be combined in many ways to create custom designs.
-- **Innocuous.** - It plays friendly w other tools like Bootstrap, MaterialUI, etc. and is web platform-agnostic.
+- **Composable.** Utils and variants can be combined in many ways to create custom designs.
+- **Innocuous.** It plays friendly with other tools like Bootstrap, MaterialUI, etc. and is web platform-agnostic.
 
 ## Local Set Up
 
@@ -36,29 +37,35 @@ To set the project up locally on your machine:
 
 Please follow Turing's shared [How to Contribute](https://www.notion.so/turingschool/How-to-Contribute-1b88e17f755c491989e4b2bc84db93c7) guide.
 
+Anything that is merged into the `main` branch will be immediately available on the `latest` version, which has been communicated to users that it may not be stable. If you'd like your changes to be on a new version, make sure to follow the guidance outlined in [contributing.md](./contributing.md).
+
 ## How To: Add a Token, Element or Component
 
 The workflow to add a token, element or component to Savile is as follows:
 
-- Touch a new `.scss` file in within the appropriate sub-directory of the css directory at the root of the project. The file name should match the name of the token/element/component you are building. Find the [terminology below](#terminology) as well as project naming conventions (coming soon).
+- Touch a new `.scss` file in within the appropriate sub-directory of the css/design_system directory at the root of the project. The file name should match the name of the token/element/component you are building. Find the [terminology below](#terminology) as well as project naming conventions (coming soon).
 - Write the CSS for your token/element/component
 - Above the CSS code, create a multi-line CSS comment. **The comment must start with two asterisks following the forward slash: `/**`**. Provide any relevant information in the comment, using the available attributes (listed below). See the following example for the specific syntax the docs generator expects:
     - `title` - this will be presented on the docs site and will be the name of the CSS file that is generated in the `docs` directory.
+    - `category` - this should match the parent directory (elements, tokens, etc.)
     - `status` - is this a draft, complete, not-maintained, etc?
+    - `value` - for variables, this should hold the value it stores. For class names, this should hold the class name wihtout the `.`
     - `description` - short description that the user of Savile will be provided with on the docs site
     - `example` - the HTML you write here will be rendered as the actual element; this provides an example of how this CSS will style the element.
+    - some optional attributes may be used based on how the page that renders it is built; defer to any similar files or make up something new that you need!
 
     ```css
     /**
-     * @title Button
-     * @status draft
-     * @description Our basic button
-     *
-     * @example
-     * <button class="button">
-     *   Click me
-     * </button>
-     */
+    * @title Base Button
+    * @category elements
+    * @element_type button
+    * @status draft
+    * @value s-button
+    * @description Our base button styles. Any other button class can be used in addition to this, to get the desired variant.
+    *
+    * @example
+    * <button class="s-button">Base Button</button>
+    */
     ```
 
 - In your terminal, run `ruby build_css_docs.rb` to run the generator, which will take the single SCSS file you created and wrote, and both feed the CSS into the design system (`_site/css`), and take the documentation and make it markdown-friendly (`docs`).
@@ -73,6 +80,8 @@ If changes are made to the S3 bucket (add/remove files), then you can update the
 ```bash
 $ ruby ./build_assets_data.rb
 ```
+
+If you'd like to add to or update the assets in the S3 bucket and don't have access, please contact @Tanner on Slack.
 
 ## Terminology
 

--- a/colors.html
+++ b/colors.html
@@ -3,9 +3,7 @@ title: Colors
 layout: default
 permalink: /colors/
 ---
-<p class="s-p">The color variables listed below are part of Savile, but are mainly intended for internal use. If one wants to use
-  the variables listed here in another project, they are available and require the CSS variable syntax (e.g.
-  <code>color: var(--s-color-gray-100);</code>).</p>
+<p class="s-p">The color variables listed below are part of Savile, but are mainly intended for internal use. If one wants to use the variables listed here in another project, they are available and require the CSS variable syntax (e.g.<code>color: var(--s-color-gray-100);</code>).</p>
 
 <table class="table">
   <thead>

--- a/colors.html
+++ b/colors.html
@@ -3,6 +3,9 @@ title: Colors
 layout: default
 permalink: /colors/
 ---
+<p class="s-p">The color variables listed below are part of Savile, but are mainly intended for internal use. If one wants to use
+  the variables listed here in another project, they are available and require the CSS variable syntax (e.g.
+  <code>color: var(--s-color-gray-100);</code>).</p>
 
 <table class="table">
   <thead>

--- a/css/design_system/typography.scss
+++ b/css/design_system/typography.scss
@@ -1,7 +1,7 @@
 /**
  * @title Heading 1
  * @category typography
- * @value .s-h1
+ * @value s-h1
  * @order 1
  */
 .s-h1	{
@@ -13,7 +13,7 @@
 /**
  * @title Heading 2
  * @category typography
- * @value .s-h2
+ * @value s-h2
  * @order 2
  */
 .s-h2	{
@@ -25,7 +25,7 @@
 /**
  * @title Heading 3
  * @category typography
- * @value .s-h3
+ * @value s-h3
  * @order 3
  */
 .s-h3	{
@@ -37,7 +37,7 @@
 /**
  * @title Heading 4
  * @category typography
- * @value .s-h4
+ * @value s-h4
  * @order 4
  */
 .s-h4	{
@@ -49,7 +49,7 @@
 /**
  * @title Heading 5
  * @category typography
- * @value .s-h5
+ * @value s-h5
  * @order 5
  */
 .s-h5	{
@@ -61,7 +61,7 @@
 /**
  * @title Heading 6
  * @category typography
- * @value .s-h6
+ * @value s-h6
  * @order 6
  */
 .s-h6	{
@@ -73,7 +73,7 @@
 /**
  * @title Body Text
  * @category typography
- * @value .s-text-body
+ * @value s-text-body
  * @order 7
  */
 .s-text-body {
@@ -85,7 +85,7 @@
 /**
  * @title Small Body Text
  * @category typography
- * @value .s-text-body-sm
+ * @value s-text-body-sm
  * @order 8
  */
 .s-text-body-sm {
@@ -97,7 +97,7 @@
 /**
  * @title Extra Small Body Text
  * @category typography
- * @value .s-text-body-xs
+ * @value s-text-body-xs
  * @order 9
  */
 .s-text-body-xs {

--- a/docs/_typography/Body Text.md
+++ b/docs/_typography/Body Text.md
@@ -1,6 +1,6 @@
 ---
 title: Body Text
 category: typography
-value: ".s-text-body"
+value: s-text-body
 order: 7
 ---

--- a/docs/_typography/Extra Small Body Text.md
+++ b/docs/_typography/Extra Small Body Text.md
@@ -1,6 +1,6 @@
 ---
 title: Extra Small Body Text
 category: typography
-value: ".s-text-body-xs"
+value: s-text-body-xs
 order: 9
 ---

--- a/docs/_typography/Heading 1.md
+++ b/docs/_typography/Heading 1.md
@@ -1,6 +1,6 @@
 ---
 title: Heading 1
 category: typography
-value: ".s-h1"
+value: s-h1
 order: 1
 ---

--- a/docs/_typography/Heading 2.md
+++ b/docs/_typography/Heading 2.md
@@ -1,6 +1,6 @@
 ---
 title: Heading 2
 category: typography
-value: ".s-h2"
+value: s-h2
 order: 2
 ---

--- a/docs/_typography/Heading 3.md
+++ b/docs/_typography/Heading 3.md
@@ -1,6 +1,6 @@
 ---
 title: Heading 3
 category: typography
-value: ".s-h3"
+value: s-h3
 order: 3
 ---

--- a/docs/_typography/Heading 4.md
+++ b/docs/_typography/Heading 4.md
@@ -1,6 +1,6 @@
 ---
 title: Heading 4
 category: typography
-value: ".s-h4"
+value: s-h4
 order: 4
 ---

--- a/docs/_typography/Heading 5.md
+++ b/docs/_typography/Heading 5.md
@@ -1,6 +1,6 @@
 ---
 title: Heading 5
 category: typography
-value: ".s-h5"
+value: s-h5
 order: 5
 ---

--- a/docs/_typography/Heading 6.md
+++ b/docs/_typography/Heading 6.md
@@ -1,6 +1,6 @@
 ---
 title: Heading 6
 category: typography
-value: ".s-h6"
+value: s-h6
 order: 6
 ---

--- a/docs/_typography/Small Body Text.md
+++ b/docs/_typography/Small Body Text.md
@@ -1,6 +1,6 @@
 ---
 title: Small Body Text
 category: typography
-value: ".s-text-body-sm"
+value: s-text-body-sm
 order: 8
 ---

--- a/index.markdown
+++ b/index.markdown
@@ -23,20 +23,20 @@ To add Savile to a project, import the URL of the version you'd like to use in t
   <tbody>
     <tr class="table-row">
       <td class="token-title-cell">1.1 - <em>latest stable release</em></td>
-      <td class="token-value-cell">
-        <a class="s-link" href="https://savile.turing.io/css/versions/v1/1.1.css" target="blank">https://savile.turing.io/css/versions/v1/1.1.css</a>
+      <td class="token-title-cell">
+        <a class="s-link" href="https://savile.turing.io/css/v1/1.1.css" target="blank">https://savile.turing.io/css/v1/1.1.css</a>
       </td>
     </tr>
     <tr class="table-row">
       <td class="token-title-cell">1.0</td>
-      <td class="token-value-cell">
-        <a class="s-link" href="https://savile.turing.io/css/versions/v1/1.0.css" target="blank">https://savile.turing.io/css/versions/v1/1.0.css</a>
+      <td class="token-title-cell">
+        <a class="s-link" href="https://savile.turing.io/css/v1/1.0.css" target="blank">https://savile.turing.io/css/v1/1.0.css</a>
       </td>
     </tr>
     <tr class="table-row">
       <td class="token-title-cell">Latest - <em>not stable, only recommended for experimental use</em></td>
-      <td class="token-value-cell">
-        <a class="s-link" href="https://savile.turing.io/css/main.css" target="blank">https://savile.turing.io/css/versions/v1/1-latest.css</a>
+      <td class="token-title-cell">
+        <a class="s-link" href="https://savile.turing.io/css/main.css" target="blank">https://savile.turing.io/css/main.css</a>
       </td>
     </tr>
   </tbody>

--- a/index.markdown
+++ b/index.markdown
@@ -1,12 +1,62 @@
 ---
-title: Savile - Turing's Design System
+title: Savile
 layout: default
 ---
 
-Welcome to Savile.
+## Turing School's Design System
 
-{% for example in site.example %}
+Nicknamed after Savile Row, Savile is the Design System for all sites and applications in the Turing Software suite. It is open-sourced though, so available for any who are interested to use!
 
-  <h2>{{ example.name }} - {{ example.position }}</h2>
-  <p>{{ example.content | markdownify }}</p>
-{% endfor %}
+### Adding Savile to an Application
+
+Savile is language and framework agnostic, so no matter what an application is built in, it can utilize this design system. This means that the setup details may vary based on the framework.
+
+To add Savile to a project, import the URL of the version you'd like to use in the appropriate place. 
+
+<table class="spaced-table">
+  <thead>
+    <tr class="table-head-row">
+      <th>Version Number</th>
+      <th>URL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr class="table-row">
+      <td class="token-title-cell">1.1 - <em>latest stable release</em></td>
+      <td class="token-value-cell">
+        <a class="s-link" href="https://savile.turing.io/css/versions/v1/1.1.css" target="blank">https://savile.turing.io/css/versions/v1/1.1.css</a>
+      </td>
+    </tr>
+    <tr class="table-row">
+      <td class="token-title-cell">1.0</td>
+      <td class="token-value-cell">
+        <a class="s-link" href="https://savile.turing.io/css/versions/v1/1.0.css" target="blank">https://savile.turing.io/css/versions/v1/1.0.css</a>
+      </td>
+    </tr>
+    <tr class="table-row">
+      <td class="token-title-cell">Latest - <em>not stable, only recommended for experimental use</em></td>
+      <td class="token-value-cell">
+        <a class="s-link" href="https://savile.turing.io/css/main.css" target="blank">https://savile.turing.io/css/versions/v1/1-latest.css</a>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+Simply importing Savile should not make any changes to your existing application. _When Savile is added to an existing Turing application, you may notice very small changes in the weight of some fonts. This is because some of the older applications use older versions of font files, and Savile will override the font source._
+
+### Using Savile in an Application
+
+Once Savile is added to your project, variables, class names, and assets will be available anywhere in your project. 
+
+In the documentation, you will find:
+- variables for Tokens and Colors
+- class names and some usage examples for Typography, Utils, Elements, and Components
+- URLs for brand assets
+
+The variables listed in Tokens and Colors are CSS variables which do work as expected in SCSS and SASS. As an example, for the variable `--s-color-cyn-400`, the following syntax needs to be used:
+
+```css
+.selector {
+  color: var(--s-color-cyan-400);
+}
+```

--- a/index.markdown
+++ b/index.markdown
@@ -5,7 +5,7 @@ layout: default
 
 ## Turing School's Design System
 
-Nicknamed after Savile Row, Savile is the Design System for all sites and applications in the Turing Software suite. It is open-sourced though, so available for any who are interested to use!
+Nicknamed after <a class="s-link" href="https://en.wikipedia.org/wiki/Savile_Row" target="blank">Savile Row</a>, Savile is the Design System for all sites and applications in the Turing Software suite. It is open-sourced though, so available for any who are interested to use!
 
 ### Adding Savile to an Application
 

--- a/index.markdown
+++ b/index.markdown
@@ -57,7 +57,7 @@ In the documentation, you will find:
 - class names and some usage examples for Typography, Utils, Elements, and Components
 - URLs for brand assets
 
-The variables listed in Tokens and Colors are CSS variables which do work as expected in SCSS and SASS. As an example, for the variable `--s-color-cyn-400`, the following syntax needs to be used:
+The variables listed in Tokens and Colors are CSS variables which do work as expected in SCSS and SASS. As an example, for the variable `--s-color-cyan-400`, the following syntax needs to be used:
 
 ```css
 .selector {

--- a/index.markdown
+++ b/index.markdown
@@ -5,57 +5,35 @@ layout: default
 
 ## Turing School's Design System
 
-Nicknamed after <a class="s-link" href="https://en.wikipedia.org/wiki/Savile_Row" target="blank">Savile Row</a>, Savile is the Design System for all sites and applications in the Turing Software suite. It is open-sourced though, so available for any who are interested to use!
+Nicknamed after <a class="s-link" href="https://en.wikipedia.org/wiki/Savile_Row" target="blank">Savile Row</a>, Savile is the Design System for all sites and applications in the Turing Software suite. It is open-sourced though, so available to anyone who is interested in using it!
 
 <br>
 
-### Adding Savile to an Application
+### Adding Savile to a Project
 
-Savile is language and framework agnostic, so no matter what an application is built in, it can utilize this design system. This means that the setup details may vary based on the framework.
+To add Savile to a project, link the version you'd like to use in the `<head>` tag of your HTML. You can find a list of versions on the <a href="https://github.com/turingschool/savile/releases" target="blank" class="s-link">releases page</a>. For example, to link version 1.1:
+```html
+<link rel="stylesheet" href="https://savile.turing.io/css/v1/1.1.css">
+```
+If you don't need to lock in a specific version, but just want the latest release for a given major version, you can reference the `-latest.css` file.
+```html
+<link rel="stylesheet" href="https://savile.turing.io/css/v1/1-latest.css">
+```
 
-To add Savile to a project, import the URL of the version you'd like to use in the appropriate place. 
+**Simply importing Savile should not change the styles of your existing application**. This is because Savile's classes are prefixed with `s-`, so the likelihood of them clashing with other CSS is very low.
 
-<table class="spaced-table">
-  <thead>
-    <tr class="table-head-row">
-      <th>Version Number</th>
-      <th>URL</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr class="table-row">
-      <td class="token-title-cell">1.1 - <em>latest stable release</em></td>
-      <td class="token-title-cell">
-        <a class="s-link" href="https://savile.turing.io/css/v1/1.1.css" target="blank">https://savile.turing.io/css/v1/1.1.css</a>
-      </td>
-    </tr>
-    <tr class="table-row">
-      <td class="token-title-cell">Latest - <em>only recommended for experimental use</em></td>
-      <td class="token-title-cell">
-        <a class="s-link" href="https://savile.turing.io/css/1-latest.css" target="blank">https://savile.turing.io/css/1-latest.css</a>
-      </td>
-    </tr>
-    <tr class="table-row">
-      <td class="token-title-cell">1.0</td>
-      <td class="token-title-cell">
-        <a class="s-link" href="https://savile.turing.io/css/v1/1.0.css" target="blank">https://savile.turing.io/css/v1/1.0.css</a>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
-Simply importing Savile should not make any changes to your existing application. _When Savile is added to an existing Turing application, you may notice very small changes in the weight of some fonts. This is because some of the older applications use older versions of font files, and Savile will override the font source._
+_Caveat: when Savile is added to an existing Turing application, you may notice very small changes in the weight of some fonts. This is because some of the older applications use older versions of font files, and Savile will override the font source._
 
 <br>
 
-### Using Savile in an Application
+### Using Savile in a Project
 
-Once Savile is added to your project, variables, class names, and assets will be available anywhere in your project. 
+Once Savile is added to your project, variables and class names will be available anywhere in your project. 
 
 In the documentation, you will find:
 - variables for Tokens and Colors
 - class names and some usage examples for Typography, Utils, Elements, and Components
-- URLs for brand assets
+- URLs for Brand Assets
 
 The variables listed in Tokens and Colors are CSS variables which do work as expected in SCSS and SASS. As an example, for the variable `--s-color-cyan-400`, the following syntax needs to be used:
 
@@ -64,3 +42,7 @@ The variables listed in Tokens and Colors are CSS variables which do work as exp
   color: var(--s-color-cyan-400);
 }
 ```
+
+#### Static Assets
+
+To learn how to use Savile's static assets like images and icons, check out the <a href="/assets" class="s-link">Assets page</a>.

--- a/index.markdown
+++ b/index.markdown
@@ -7,6 +7,8 @@ layout: default
 
 Nicknamed after <a class="s-link" href="https://en.wikipedia.org/wiki/Savile_Row" target="blank">Savile Row</a>, Savile is the Design System for all sites and applications in the Turing Software suite. It is open-sourced though, so available for any who are interested to use!
 
+<br>
+
 ### Adding Savile to an Application
 
 Savile is language and framework agnostic, so no matter what an application is built in, it can utilize this design system. This means that the setup details may vary based on the framework.
@@ -28,21 +30,23 @@ To add Savile to a project, import the URL of the version you'd like to use in t
       </td>
     </tr>
     <tr class="table-row">
-      <td class="token-title-cell">1.0</td>
+      <td class="token-title-cell">Latest - <em>only recommended for experimental use</em></td>
       <td class="token-title-cell">
-        <a class="s-link" href="https://savile.turing.io/css/v1/1.0.css" target="blank">https://savile.turing.io/css/v1/1.0.css</a>
+        <a class="s-link" href="https://savile.turing.io/css/1-latest.css" target="blank">https://savile.turing.io/css/1-latest.css</a>
       </td>
     </tr>
     <tr class="table-row">
-      <td class="token-title-cell">Latest - <em>not stable, only recommended for experimental use</em></td>
+      <td class="token-title-cell">1.0</td>
       <td class="token-title-cell">
-        <a class="s-link" href="https://savile.turing.io/css/main.css" target="blank">https://savile.turing.io/css/main.css</a>
+        <a class="s-link" href="https://savile.turing.io/css/v1/1.0.css" target="blank">https://savile.turing.io/css/v1/1.0.css</a>
       </td>
     </tr>
   </tbody>
 </table>
 
 Simply importing Savile should not make any changes to your existing application. _When Savile is added to an existing Turing application, you may notice very small changes in the weight of some fonts. This is because some of the older applications use older versions of font files, and Savile will override the font source._
+
+<br>
 
 ### Using Savile in an Application
 

--- a/index.markdown
+++ b/index.markdown
@@ -35,14 +35,6 @@ In the documentation, you will find:
 - class names and some usage examples for Typography, Utils, Elements, and Components
 - URLs for Brand Assets
 
-The variables listed in Tokens and Colors are CSS variables which do work as expected in SCSS and SASS. As an example, for the variable `--s-color-cyan-400`, the following syntax needs to be used:
-
-```css
-.selector {
-  color: var(--s-color-cyan-400);
-}
-```
-
 #### Static Assets
 
 To learn how to use Savile's static assets like images and icons, check out the <a href="/assets" class="s-link">Assets page</a>.

--- a/tokens.html
+++ b/tokens.html
@@ -10,6 +10,8 @@ subnav:
   font-family: Font Family
 ---
 
+<p class="s-p">The tokens listed below are part of Savile, but are mainly intended for internal use. If one wants to use the variables listed here in another project, they are available and require the CSS variable syntax (e.g. <code>color: var(--s-color-gray-100);</code>).</p>
+
 {% assign grouped_tokens = site.tokens | group_by: "token_type" %}
 
 {% for token_group in grouped_tokens %}

--- a/typography.html
+++ b/typography.html
@@ -5,7 +5,7 @@ permalink: /typography/
 ---
 
 <p>The available Typography classes only provide font-family, font-size and font-weight. See <a href="{{site.url}}/elements" class="s-link">Elements -> Paragraph</a> text for color variations on paragraph elements, and <a href="{{site.url}}/colors" class="s-link">Colors</a> for color usage recommendations with text.</p>
-<table class="token-table">
+<table class="spaced-table">
   <thead>
     <tr class="table-head-row">
       <th>Class Name</th>

--- a/utils.html
+++ b/utils.html
@@ -20,10 +20,10 @@ permalink: /utils/
   </thead>
   {% for util in utils %}
   <tr class="table-row">
-    <td class="util-class-cell">.{{ util.title }}</td>
+    <td class="util-class-cell">{% highlight html %}{{ util.title }}{% endhighlight %}</td>
     <td class="token-value-cell">{% highlight html %}{{ util | remove: '<p>' | remove: '</p>' }}{% endhighlight %}</td>
-    <td class="token-example-cell">{{ util }}</td>
+    <td class="element-sample-cell">{{ util }}</td>
   </tr>
   {% endfor %}
 </table>
-{% endfor %}hh
+{% endfor %}


### PR DESCRIPTION
#### What does this PR do?

- Makes a few changes to the README to reflect changes we've made to Savile since the original README. Some things were slightly out of date, a couple typos, etc.
- A couple clean-up pieces around doc site. Make all class names render in monospace and without the `.` before it, get the Tokens and Utils tables to match the other tables a little better.
- BIG ADDITION: main page of Savile now has a little introduction and setup "instructions"

#### Where should the reviewer start?

- `index.md`

#### How should this be manually tested?

If you'd like to run locally and click around. I am also adding a screenshot so you can see formatting of the index page.

#### Any background context you want to provide?

#### What are the relevant tickets?

https://3.basecamp.com/3494409/buckets/19192671/todos/3614858608

#### Screenshots (if appropriate) - updated after first review

<img width="1552" alt="Screen Shot 2021-04-13 at 11 22 49 AM" src="https://user-images.githubusercontent.com/25447342/114594569-a2eebd00-9c4a-11eb-9b13-43730eb67ddf.png">

<img width="1552" alt="Screen Shot 2021-04-16 at 9 13 20 AM" src="https://user-images.githubusercontent.com/25447342/115045748-07508d00-9e94-11eb-816f-fe50abe8581a.png">

#### Any other deploy steps?

No