### PR TITLE
WIP: Add s-content class

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,6 @@ collections:
   colors:
     sort_by: title
   content:
-    sort_by: order
   typography:
     sort_by: order
   utils:

--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,8 @@ collections:
     sort_by: order
   colors:
     sort_by: title
+  content:
+    sort_by: order
   typography:
     sort_by: order
   utils:

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -4,6 +4,8 @@
   url: /tokens/
 - text: Colors
   url: /colors/
+- text: Styling Content
+  url: /content/
 - text: Typography
   url: /typography/
 - text: Utils

--- a/content.html
+++ b/content.html
@@ -6,27 +6,9 @@ permalink: /content/
 
 <p>The <code>s-content</code> class can be used on any element where you want to style all the contents of that element. It will apply styles to the paragraphs using <code>.s-p</code> and links using <code>.s-link</code>, so you don't have to add those classes directly to every corresponding element.</p>
 
-<table class="spaced-table">
-  <thead>
-    <tr class="table-head-row">
-      <th>Class Name</th>
-      <th>HTML Example</th>
-      <th>Example Output</th>
-    </tr>
-  </thead>
-  {% for content in site.content %}
-  <tr class="table-row">
-    <td class="util-class-cell">
-      <code>{{ content.value }}</code>
-    </td>
-    <td class="util-value-cell">
-      {% highlight html %}{{ content }}{% endhighlight %}
-    </td>
-    <td class="util-example-cell">
-      <div class="example-container">
-        {{ content | remove: '<p>' | remove: '</p>' }}
-      </div>
-    </td>
-  </tr>
-  {% endfor %}
-</table>
+{% assign s_content = site.content | first %}
+<h2>Using <code>{{ s_content.value }}</code></h2>
+<h3>HTML Example:</h3>
+{% highlight html %}{{ s_content }}{% endhighlight %}
+<h3>Output Example:</h3>
+{{ s_content | remove: '<p>' | remove: '</p>' }}

--- a/content.html
+++ b/content.html
@@ -1,0 +1,32 @@
+---
+title: Styling Content
+layout: default
+permalink: /content/
+---
+
+<p>The <code>s-content</code> class can be used on any element where you want to style all the contents of that element. It will apply styles to the paragraphs using <code>.s-p</code> and links using <code>.s-link</code>, so you don't have to add those classes directly to every corresponding element.</p>
+
+<table class="spaced-table">
+  <thead>
+    <tr class="table-head-row">
+      <th>Class Name</th>
+      <th>HTML Example</th>
+      <th>Example Output</th>
+    </tr>
+  </thead>
+  {% for content in site.content %}
+  <tr class="table-row">
+    <td class="util-class-cell">
+      <code>{{ content.value }}</code>
+    </td>
+    <td class="util-value-cell">
+      {% highlight html %}{{ content }}{% endhighlight %}
+    </td>
+    <td class="util-example-cell">
+      <div class="example-container">
+        {{ content | remove: '<p>' | remove: '</p>' }}
+      </div>
+    </td>
+  </tr>
+  {% endfor %}
+</table>

--- a/css/design_system/content.scss
+++ b/css/design_system/content.scss
@@ -1,7 +1,7 @@
 /**
  * @title Savile Content
  * @category content
- * @description Our base content styles. If this class is added to the body tag (or any container tag), all it's children will receive this styling.
+ * @description Our base content styles. If this class is added to the body tag (or any container tag), all its children will receive this styling.
  * @value .s-content
  *
  * @example

--- a/css/design_system/content.scss
+++ b/css/design_system/content.scss
@@ -1,0 +1,22 @@
+/**
+ * @title Savile Content
+ * @category content
+ * @description Our base content styles. If this class is added to the body tag (or any container tag), all it's children will receive this styling.
+ * @value .s-content
+ *
+ * @example
+ * <section class="s-content">
+ *  <p>Sample paragraph</p>
+ *  <a href="">Sample link</a>
+ * </section>
+ */
+
+.s-content {
+  p {
+    @extend .s-p;
+  }
+  a {
+    @extend .s-link;
+  }
+}
+

--- a/css/design_system/elements/button.scss
+++ b/css/design_system/elements/button.scss
@@ -22,11 +22,11 @@
   display: inline-block;
   line-height: 17px;
   letter-spacing: .5px; 
-  text-decoration: none;
+  text-decoration: none !important;
   text-transform: uppercase;
   cursor: pointer;
 
-  color: var(--s-color-gray-100);
+  color: var(--s-color-gray-100) !important;
   background-color: var(--s-color-gray-700);
 }
 
@@ -43,7 +43,7 @@
  */
  
 .s-button-primary {
-  color: var(--s-color-cyan-700);
+  color: var(--s-color-cyan-700) !important;
   background-color: var(--s-color-cyan-400);
 }
 
@@ -60,7 +60,7 @@
  **/
  
 .s-button-primary-inverse {
-  color: var(--s-color-cyan-400);
+  color: var(--s-color-cyan-400) !important;
   background-color: var(--s-color-cyan-700);
 }
 
@@ -77,7 +77,7 @@
  */
  
 .s-button-secondary {
-  color: var(--s-color-gray-700);
+  color: var(--s-color-gray-700) !important;
   background-color: var(--s-color-gray-100);
   border: 2px solid var(--s-color-gray-700);
 }

--- a/css/design_system/index.scss
+++ b/css/design_system/index.scss
@@ -2,7 +2,6 @@
 @import "tokens/spacing";
 @import "tokens/shadows";
 
-@import "content";
 @import "colors";
 @import "typography";
 
@@ -12,5 +11,7 @@
 @import "elements/button";
 @import "elements/link";
 @import "elements/p";
+
+@import "content";
 
 @import "components/nav";

--- a/css/design_system/index.scss
+++ b/css/design_system/index.scss
@@ -2,6 +2,7 @@
 @import "tokens/spacing";
 @import "tokens/shadows";
 
+@import "content";
 @import "colors";
 @import "typography";
 

--- a/docs/_components/Primary Nav.md
+++ b/docs/_components/Primary Nav.md
@@ -3,7 +3,7 @@ title: Primary Nav
 category: components
 status: early draft
 description: Navigation component w/ primary and secondary variants.
-order: 116
+order: 117
 ---
 <nav class="nav nav-primary">
   <ul>

--- a/docs/_content/Savile Content.md
+++ b/docs/_content/Savile Content.md
@@ -1,0 +1,12 @@
+---
+title: Savile Content
+category: content
+description: Our base content styles. If this class is added to the body tag (or any
+  container tag), all it's children will receive this styling.
+value: ".s-content"
+order: 1
+---
+<section class="s-content">
+ <p>Sample paragraph</p>
+ <a href="">Sample link</a>
+</section>

--- a/docs/_elements/Base Button.md
+++ b/docs/_elements/Base Button.md
@@ -6,6 +6,6 @@ status: draft
 value: s-button
 description: Our base button styles. Any other button class can be used in addition
   to this, to get the desired variant.
-order: 109
+order: 110
 ---
 <button class="s-button">Base Button</button>

--- a/docs/_elements/Link.md
+++ b/docs/_elements/Link.md
@@ -5,6 +5,6 @@ element_type: link
 status: draft
 value: s-link
 description: Styles for a link that is embedded in the default paragraph text.
-order: 113
+order: 114
 ---
 <a class="s-link">contact our team</a>

--- a/docs/_elements/Paragraph Variant.md
+++ b/docs/_elements/Paragraph Variant.md
@@ -6,6 +6,6 @@ status: draft
 value: n/a
 description: A paragraph element with built-in size, color, and font-family. To be
   used with a white background.
-order: 115
+order: 116
 ---
 <p class="s-p s-text-body-xs">This example shows how other utils can be used to achieve variants of the base paragraph.</p>

--- a/docs/_elements/Paragraph.md
+++ b/docs/_elements/Paragraph.md
@@ -6,6 +6,6 @@ status: draft
 value: s-p
 description: A paragraph element with built-in size, color, and font-family. To be
   used with a white background.
-order: 114
+order: 115
 ---
 <p class="s-p">The default paragraph text is 16px and is intended for text on a white background.</p>

--- a/docs/_elements/Primary Button.md
+++ b/docs/_elements/Primary Button.md
@@ -6,6 +6,6 @@ status: draft
 value: s-button-primary
 description: Our primary call-to-action button for specific actions - apply, register
   for Try Coding, subscribe to newsletter, etc.
-order: 110
+order: 111
 ---
 <button class="s-button s-button-primary">Primary</button>

--- a/docs/_elements/Primary Inverse Button.md
+++ b/docs/_elements/Primary Inverse Button.md
@@ -6,6 +6,6 @@ status: draft
 value: s-button-primary-inverse
 description: Our primary call-to-action button, with inverse colors. These are usually
   used for buttons that lead user to more info.
-order: 111
+order: 112
 ---
 <button class="s-button s-button-primary-inverse">Primary Inverse</button>

--- a/docs/_elements/Secondary Button.md
+++ b/docs/_elements/Secondary Button.md
@@ -6,6 +6,6 @@ status: draft
 value: s-button-secondary
 description: Our secondary call-to-action button for specific actions - apply, register
   for Try Coding, subscribe to newsletter, etc.
-order: 112
+order: 113
 ---
 <button class="s-button s-button-secondary">Secondary</button>

--- a/docs/_typography/Body Text.md
+++ b/docs/_typography/Body Text.md
@@ -2,5 +2,5 @@
 title: Body Text
 category: typography
 value: s-text-body
-order: 7
+order: 8
 ---

--- a/docs/_typography/Extra Small Body Text.md
+++ b/docs/_typography/Extra Small Body Text.md
@@ -2,5 +2,5 @@
 title: Extra Small Body Text
 category: typography
 value: s-text-body-xs
-order: 9
+order: 10
 ---

--- a/docs/_typography/Heading 1.md
+++ b/docs/_typography/Heading 1.md
@@ -2,5 +2,5 @@
 title: Heading 1
 category: typography
 value: s-h1
-order: 1
+order: 2
 ---

--- a/docs/_typography/Heading 2.md
+++ b/docs/_typography/Heading 2.md
@@ -2,5 +2,5 @@
 title: Heading 2
 category: typography
 value: s-h2
-order: 2
+order: 3
 ---

--- a/docs/_typography/Heading 3.md
+++ b/docs/_typography/Heading 3.md
@@ -2,5 +2,5 @@
 title: Heading 3
 category: typography
 value: s-h3
-order: 3
+order: 4
 ---

--- a/docs/_typography/Heading 4.md
+++ b/docs/_typography/Heading 4.md
@@ -2,5 +2,5 @@
 title: Heading 4
 category: typography
 value: s-h4
-order: 4
+order: 5
 ---

--- a/docs/_typography/Heading 5.md
+++ b/docs/_typography/Heading 5.md
@@ -2,5 +2,5 @@
 title: Heading 5
 category: typography
 value: s-h5
-order: 5
+order: 6
 ---

--- a/docs/_typography/Heading 6.md
+++ b/docs/_typography/Heading 6.md
@@ -2,5 +2,5 @@
 title: Heading 6
 category: typography
 value: s-h6
-order: 6
+order: 7
 ---

--- a/docs/_typography/Small Body Text.md
+++ b/docs/_typography/Small Body Text.md
@@ -2,5 +2,5 @@
 title: Small Body Text
 category: typography
 value: s-text-body-sm
-order: 8
+order: 9
 ---

--- a/docs/_utils/s-border-bottom.md
+++ b/docs/_utils/s-border-bottom.md
@@ -3,6 +3,6 @@ title: s-border-bottom
 category: utils
 util_type: border
 border_group: sides
-order: 97
+order: 98
 ---
 <span class="s-border-bottom"></span>

--- a/docs/_utils/s-border-left.md
+++ b/docs/_utils/s-border-left.md
@@ -3,6 +3,6 @@ title: s-border-left
 category: utils
 util_type: border
 border_group: sides
-order: 98
+order: 99
 ---
 <span class="s-border-left"></span>

--- a/docs/_utils/s-border-radius-0.md
+++ b/docs/_utils/s-border-radius-0.md
@@ -3,6 +3,6 @@ title: s-border-radius-0
 category: utils
 util_type: border
 border_group: radius
-order: 104
+order: 105
 ---
 <span class="s-border-radius-0"></span>

--- a/docs/_utils/s-border-radius-1.md
+++ b/docs/_utils/s-border-radius-1.md
@@ -3,6 +3,6 @@ title: s-border-radius-1
 category: utils
 util_type: border
 border_group: radius
-order: 105
+order: 106
 ---
 <span class="s-border-radius-1"></span>

--- a/docs/_utils/s-border-radius-2.md
+++ b/docs/_utils/s-border-radius-2.md
@@ -3,6 +3,6 @@ title: s-border-radius-2
 category: utils
 util_type: border
 border_group: radius
-order: 106
+order: 107
 ---
 <span class="s-border-radius-2"></span>

--- a/docs/_utils/s-border-radius-circle.md
+++ b/docs/_utils/s-border-radius-circle.md
@@ -3,6 +3,6 @@ title: s-border-radius-circle
 category: utils
 util_type: border
 border_group: radius
-order: 107
+order: 108
 ---
 <span class="s-border-radius-circle"></span>

--- a/docs/_utils/s-border-radius-pill.md
+++ b/docs/_utils/s-border-radius-pill.md
@@ -3,6 +3,6 @@ title: s-border-radius-pill
 category: utils
 util_type: border
 border_group: radius
-order: 108
+order: 109
 ---
 <span class="s-border-radius-pill"></span>

--- a/docs/_utils/s-border-right.md
+++ b/docs/_utils/s-border-right.md
@@ -3,6 +3,6 @@ title: s-border-right
 category: utils
 util_type: border
 border_group: sides
-order: 96
+order: 97
 ---
 <span class="s-border-right"></span>

--- a/docs/_utils/s-border-top.md
+++ b/docs/_utils/s-border-top.md
@@ -3,6 +3,6 @@ title: s-border-top
 category: utils
 util_type: border
 border_group: sides
-order: 95
+order: 96
 ---
 <span class="s-border-top"></span>

--- a/docs/_utils/s-border-width-0.md
+++ b/docs/_utils/s-border-width-0.md
@@ -3,6 +3,6 @@ title: s-border-width-0
 category: utils
 util_type: border
 border_group: width
-order: 99
+order: 100
 ---
 <span class="s-border s-border-width-0"></span>

--- a/docs/_utils/s-border-width-1.md
+++ b/docs/_utils/s-border-width-1.md
@@ -3,6 +3,6 @@ title: s-border-width-1
 category: utils
 util_type: border
 border_group: width
-order: 100
+order: 101
 ---
 <span class="s-border s-border-width-1"></span>

--- a/docs/_utils/s-border-width-2.md
+++ b/docs/_utils/s-border-width-2.md
@@ -3,6 +3,6 @@ title: s-border-width-2
 category: utils
 util_type: border
 border_group: width
-order: 101
+order: 102
 ---
 <span class="s-border s-border-width-2"></span>

--- a/docs/_utils/s-border-width-3.md
+++ b/docs/_utils/s-border-width-3.md
@@ -3,6 +3,6 @@ title: s-border-width-3
 category: utils
 util_type: border
 border_group: width
-order: 102
+order: 103
 ---
 <span class="s-border s-border-width-3"></span>

--- a/docs/_utils/s-border-width-4.md
+++ b/docs/_utils/s-border-width-4.md
@@ -3,6 +3,6 @@ title: s-border-width-4
 category: utils
 util_type: border
 border_group: width
-order: 103
+order: 104
 ---
 <span class="s-border s-border-width-4"></span>

--- a/docs/_utils/s-border.md
+++ b/docs/_utils/s-border.md
@@ -3,6 +3,6 @@ title: s-border
 category: utils
 util_type: border
 border_group: sides
-order: 94
+order: 95
 ---
 <span class="s-border"></span>

--- a/docs/_utils/s-m-0.md
+++ b/docs/_utils/s-m-0.md
@@ -2,7 +2,7 @@
 title: s-m-0
 category: utils
 util_type: margin
-order: 52
+order: 53
 ---
 <div class="s-m-0">
   <code>s-m-0</code>

--- a/docs/_utils/s-m-1.md
+++ b/docs/_utils/s-m-1.md
@@ -2,7 +2,7 @@
 title: s-m-1
 category: utils
 util_type: margin
-order: 59
+order: 60
 ---
 <div class="s-m-1">
   <code>s-m-1</code>

--- a/docs/_utils/s-m-2.md
+++ b/docs/_utils/s-m-2.md
@@ -2,7 +2,7 @@
 title: s-m-2
 category: utils
 util_type: margin
-order: 66
+order: 67
 ---
 <div class="s-m-2">
   <code>s-m-2</code>

--- a/docs/_utils/s-m-3.md
+++ b/docs/_utils/s-m-3.md
@@ -2,7 +2,7 @@
 title: s-m-3
 category: utils
 util_type: margin
-order: 73
+order: 74
 ---
 <div class="s-m-3">
   <code>s-m-3</code>

--- a/docs/_utils/s-m-4.md
+++ b/docs/_utils/s-m-4.md
@@ -2,7 +2,7 @@
 title: s-m-4
 category: utils
 util_type: margin
-order: 80
+order: 81
 ---
 <div class="s-m-4">
   <code>s-m-4</code>

--- a/docs/_utils/s-m-5.md
+++ b/docs/_utils/s-m-5.md
@@ -2,7 +2,7 @@
 title: s-m-5
 category: utils
 util_type: margin
-order: 87
+order: 88
 ---
 <div class="s-m-5">
   <code>s-m-5</code>

--- a/docs/_utils/s-mb-0.md
+++ b/docs/_utils/s-mb-0.md
@@ -2,7 +2,7 @@
 title: s-mb-0
 category: utils
 util_type: margin
-order: 57
+order: 58
 ---
 <div class="s-mb-0">
   <code>s-mb-0</code>

--- a/docs/_utils/s-mb-1.md
+++ b/docs/_utils/s-mb-1.md
@@ -2,7 +2,7 @@
 title: s-mb-1
 category: utils
 util_type: margin
-order: 64
+order: 65
 ---
 <div class="s-mb-1">
   <code>s-mb-1</code>

--- a/docs/_utils/s-mb-2.md
+++ b/docs/_utils/s-mb-2.md
@@ -2,7 +2,7 @@
 title: s-mb-2
 category: utils
 util_type: margin
-order: 71
+order: 72
 ---
 <div class="s-mb-2">
   <code>s-mb-2</code>

--- a/docs/_utils/s-mb-3.md
+++ b/docs/_utils/s-mb-3.md
@@ -2,7 +2,7 @@
 title: s-mb-3
 category: utils
 util_type: margin
-order: 78
+order: 79
 ---
 <div class="s-mb-3">
   <code>s-mb-3</code>

--- a/docs/_utils/s-mb-4.md
+++ b/docs/_utils/s-mb-4.md
@@ -2,7 +2,7 @@
 title: s-mb-4
 category: utils
 util_type: margin
-order: 85
+order: 86
 ---
 <div class="s-mb-4">
   <code>s-mb-4</code>

--- a/docs/_utils/s-mb-5.md
+++ b/docs/_utils/s-mb-5.md
@@ -2,7 +2,7 @@
 title: s-mb-5
 category: utils
 util_type: margin
-order: 92
+order: 93
 ---
 <div class="s-mb-5">
   <code>s-mb-5</code>

--- a/docs/_utils/s-ml-0.md
+++ b/docs/_utils/s-ml-0.md
@@ -2,7 +2,7 @@
 title: s-ml-0
 category: utils
 util_type: margin
-order: 58
+order: 59
 ---
 <div class="s-ml-0">
   <code>s-ml-0</code>

--- a/docs/_utils/s-ml-1.md
+++ b/docs/_utils/s-ml-1.md
@@ -2,7 +2,7 @@
 title: s-ml-1
 category: utils
 util_type: margin
-order: 65
+order: 66
 ---
 <div class="s-ml-1">
   <code>s-ml-1</code>

--- a/docs/_utils/s-ml-2.md
+++ b/docs/_utils/s-ml-2.md
@@ -2,7 +2,7 @@
 title: s-ml-2
 category: utils
 util_type: margin
-order: 72
+order: 73
 ---
 <div class="s-ml-2">
   <code>s-ml-2</code>

--- a/docs/_utils/s-ml-3.md
+++ b/docs/_utils/s-ml-3.md
@@ -2,7 +2,7 @@
 title: s-ml-3
 category: utils
 util_type: margin
-order: 79
+order: 80
 ---
 <div class="s-ml-3">
   <code>s-ml-3</code>

--- a/docs/_utils/s-ml-4.md
+++ b/docs/_utils/s-ml-4.md
@@ -2,7 +2,7 @@
 title: s-ml-4
 category: utils
 util_type: margin
-order: 86
+order: 87
 ---
 <div class="s-ml-4">
   <code>s-ml-4</code>

--- a/docs/_utils/s-ml-5.md
+++ b/docs/_utils/s-ml-5.md
@@ -2,7 +2,7 @@
 title: s-ml-5
 category: utils
 util_type: margin
-order: 93
+order: 94
 ---
 <div class="s-ml-5">
   <code>s-ml-5</code>

--- a/docs/_utils/s-mr-0.md
+++ b/docs/_utils/s-mr-0.md
@@ -2,7 +2,7 @@
 title: s-mr-0
 category: utils
 util_type: margin
-order: 56
+order: 57
 ---
 <div class="s-mr-0">
   <code>s-mr-0</code>

--- a/docs/_utils/s-mr-1.md
+++ b/docs/_utils/s-mr-1.md
@@ -2,7 +2,7 @@
 title: s-mr-1
 category: utils
 util_type: margin
-order: 63
+order: 64
 ---
 <div class="s-mr-1">
   <code>s-mr-1</code>

--- a/docs/_utils/s-mr-2.md
+++ b/docs/_utils/s-mr-2.md
@@ -2,7 +2,7 @@
 title: s-mr-2
 category: utils
 util_type: margin
-order: 70
+order: 71
 ---
 <div class="s-mr-2">
   <code>s-mr-2</code>

--- a/docs/_utils/s-mr-3.md
+++ b/docs/_utils/s-mr-3.md
@@ -2,7 +2,7 @@
 title: s-mr-3
 category: utils
 util_type: margin
-order: 77
+order: 78
 ---
 <div class="s-mr-3">
   <code>s-mr-3</code>

--- a/docs/_utils/s-mr-4.md
+++ b/docs/_utils/s-mr-4.md
@@ -2,7 +2,7 @@
 title: s-mr-4
 category: utils
 util_type: margin
-order: 84
+order: 85
 ---
 <div class="s-mr-4">
   <code>s-mr-4</code>

--- a/docs/_utils/s-mr-5.md
+++ b/docs/_utils/s-mr-5.md
@@ -2,7 +2,7 @@
 title: s-mr-5
 category: utils
 util_type: margin
-order: 91
+order: 92
 ---
 <div class="s-mr-5">
   <code>s-mr-5</code>

--- a/docs/_utils/s-mt-0.md
+++ b/docs/_utils/s-mt-0.md
@@ -2,7 +2,7 @@
 title: s-mt-0
 category: utils
 util_type: margin
-order: 55
+order: 56
 ---
 <div class="s-mt-0">
   <code>s-mt-0</code>

--- a/docs/_utils/s-mt-1.md
+++ b/docs/_utils/s-mt-1.md
@@ -2,7 +2,7 @@
 title: s-mt-1
 category: utils
 util_type: margin
-order: 62
+order: 63
 ---
 <div class="s-mt-1">
   <code>s-mt-1</code>

--- a/docs/_utils/s-mt-2.md
+++ b/docs/_utils/s-mt-2.md
@@ -2,7 +2,7 @@
 title: s-mt-2
 category: utils
 util_type: margin
-order: 69
+order: 70
 ---
 <div class="s-mt-2">
   <code>s-mt-2</code>

--- a/docs/_utils/s-mt-3.md
+++ b/docs/_utils/s-mt-3.md
@@ -2,7 +2,7 @@
 title: s-mt-3
 category: utils
 util_type: margin
-order: 76
+order: 77
 ---
 <div class="s-mt-3">
   <code>s-mt-3</code>

--- a/docs/_utils/s-mt-4.md
+++ b/docs/_utils/s-mt-4.md
@@ -2,7 +2,7 @@
 title: s-mt-4
 category: utils
 util_type: margin
-order: 83
+order: 84
 ---
 <div class="s-mt-4">
   <code>s-mt-4</code>

--- a/docs/_utils/s-mt-5.md
+++ b/docs/_utils/s-mt-5.md
@@ -2,7 +2,7 @@
 title: s-mt-5
 category: utils
 util_type: margin
-order: 90
+order: 91
 ---
 <div class="s-mt-5">
   <code>s-mt-5</code>

--- a/docs/_utils/s-mx-0.md
+++ b/docs/_utils/s-mx-0.md
@@ -2,7 +2,7 @@
 title: s-mx-0
 category: utils
 util_type: margin
-order: 53
+order: 54
 ---
 <div class="s-mx-0">
   <code>s-mx-0</code>

--- a/docs/_utils/s-mx-1.md
+++ b/docs/_utils/s-mx-1.md
@@ -2,7 +2,7 @@
 title: s-mx-1
 category: utils
 util_type: margin
-order: 60
+order: 61
 ---
 <div class="s-mx-1">
   <code>s-mx-1</code>

--- a/docs/_utils/s-mx-2.md
+++ b/docs/_utils/s-mx-2.md
@@ -2,7 +2,7 @@
 title: s-mx-2
 category: utils
 util_type: margin
-order: 67
+order: 68
 ---
 <div class="s-mx-2">
   <code>s-mx-2</code>

--- a/docs/_utils/s-mx-3.md
+++ b/docs/_utils/s-mx-3.md
@@ -2,7 +2,7 @@
 title: s-mx-3
 category: utils
 util_type: margin
-order: 74
+order: 75
 ---
 <div class="s-mx-3">
   <code>s-mx-3</code>

--- a/docs/_utils/s-mx-4.md
+++ b/docs/_utils/s-mx-4.md
@@ -2,7 +2,7 @@
 title: s-mx-4
 category: utils
 util_type: margin
-order: 81
+order: 82
 ---
 <div class="s-mx-4">
   <code>s-mx-4</code>

--- a/docs/_utils/s-mx-5.md
+++ b/docs/_utils/s-mx-5.md
@@ -2,7 +2,7 @@
 title: s-mx-5
 category: utils
 util_type: margin
-order: 88
+order: 89
 ---
 <div class="s-mx-5">
   <code>s-mx-5</code>

--- a/docs/_utils/s-my-0.md
+++ b/docs/_utils/s-my-0.md
@@ -2,7 +2,7 @@
 title: s-my-0
 category: utils
 util_type: margin
-order: 54
+order: 55
 ---
 <div class="s-my-0">
   <code>s-my-0</code>

--- a/docs/_utils/s-my-1.md
+++ b/docs/_utils/s-my-1.md
@@ -2,7 +2,7 @@
 title: s-my-1
 category: utils
 util_type: margin
-order: 61
+order: 62
 ---
 <div class="s-my-1">
   <code>s-my-1</code>

--- a/docs/_utils/s-my-2.md
+++ b/docs/_utils/s-my-2.md
@@ -2,7 +2,7 @@
 title: s-my-2
 category: utils
 util_type: margin
-order: 68
+order: 69
 ---
 <div class="s-my-2">
   <code>s-my-2</code>

--- a/docs/_utils/s-my-3.md
+++ b/docs/_utils/s-my-3.md
@@ -2,7 +2,7 @@
 title: s-my-3
 category: utils
 util_type: margin
-order: 75
+order: 76
 ---
 <div class="s-my-3">
   <code>s-my-3</code>

--- a/docs/_utils/s-my-4.md
+++ b/docs/_utils/s-my-4.md
@@ -2,7 +2,7 @@
 title: s-my-4
 category: utils
 util_type: margin
-order: 82
+order: 83
 ---
 <div class="s-my-4">
   <code>s-my-4</code>

--- a/docs/_utils/s-my-5.md
+++ b/docs/_utils/s-my-5.md
@@ -2,7 +2,7 @@
 title: s-my-5
 category: utils
 util_type: margin
-order: 89
+order: 90
 ---
 <div class="s-my-5">
   <code>s-my-5</code>

--- a/docs/_utils/s-p-0.md
+++ b/docs/_utils/s-p-0.md
@@ -2,7 +2,7 @@
 title: s-p-0
 category: utils
 util_type: padding
-order: 10
+order: 11
 ---
 <div class="s-p-0">
   <code>s-p-0</code>

--- a/docs/_utils/s-p-1.md
+++ b/docs/_utils/s-p-1.md
@@ -2,7 +2,7 @@
 title: s-p-1
 category: utils
 util_type: padding
-order: 17
+order: 18
 ---
 <div class="s-p-1">
   <code>s-p-1</code>

--- a/docs/_utils/s-p-2.md
+++ b/docs/_utils/s-p-2.md
@@ -2,7 +2,7 @@
 title: s-p-2
 category: utils
 util_type: padding
-order: 24
+order: 25
 ---
 <div class="s-p-2">
   <code>s-p-2</code>

--- a/docs/_utils/s-p-3.md
+++ b/docs/_utils/s-p-3.md
@@ -2,7 +2,7 @@
 title: s-p-3
 category: utils
 util_type: padding
-order: 31
+order: 32
 ---
 <div class="s-p-3">
   <code>s-p-3</code>

--- a/docs/_utils/s-p-4.md
+++ b/docs/_utils/s-p-4.md
@@ -2,7 +2,7 @@
 title: s-p-4
 category: utils
 util_type: padding
-order: 38
+order: 39
 ---
 <div class="s-p-4">
   <code>s-p-4</code>

--- a/docs/_utils/s-p-5.md
+++ b/docs/_utils/s-p-5.md
@@ -2,7 +2,7 @@
 title: s-p-5
 category: utils
 util_type: padding
-order: 45
+order: 46
 ---
 <div class="s-p-5">
   <code>s-p-5</code>

--- a/docs/_utils/s-pb-0.md
+++ b/docs/_utils/s-pb-0.md
@@ -2,7 +2,7 @@
 title: s-pb-0
 category: utils
 util_type: padding
-order: 15
+order: 16
 ---
 <div class="s-pb-0">
   <code>s-pb-0</code>

--- a/docs/_utils/s-pb-1.md
+++ b/docs/_utils/s-pb-1.md
@@ -2,7 +2,7 @@
 title: s-pb-1
 category: utils
 util_type: padding
-order: 22
+order: 23
 ---
 <div class="s-pb-1">
   <code>s-pb-1</code>

--- a/docs/_utils/s-pb-2.md
+++ b/docs/_utils/s-pb-2.md
@@ -2,7 +2,7 @@
 title: s-pb-2
 category: utils
 util_type: padding
-order: 29
+order: 30
 ---
 <div class="s-pb-2">
   <code>s-pb-2</code>

--- a/docs/_utils/s-pb-3.md
+++ b/docs/_utils/s-pb-3.md
@@ -2,7 +2,7 @@
 title: s-pb-3
 category: utils
 util_type: padding
-order: 36
+order: 37
 ---
 <div class="s-pb-3">
   <code>s-pb-3</code>

--- a/docs/_utils/s-pb-4.md
+++ b/docs/_utils/s-pb-4.md
@@ -2,7 +2,7 @@
 title: s-pb-4
 category: utils
 util_type: padding
-order: 43
+order: 44
 ---
 <div class="s-pb-4">
   <code>s-pb-4</code>

--- a/docs/_utils/s-pb-5.md
+++ b/docs/_utils/s-pb-5.md
@@ -2,7 +2,7 @@
 title: s-pb-5
 category: utils
 util_type: padding
-order: 50
+order: 51
 ---
 <div class="s-pb-5">
   <code>s-pb-5</code>

--- a/docs/_utils/s-pl-0.md
+++ b/docs/_utils/s-pl-0.md
@@ -2,7 +2,7 @@
 title: s-pl-0
 category: utils
 util_type: padding
-order: 16
+order: 17
 ---
 <div class="s-pl-0">
   <code>s-pl-0</code>

--- a/docs/_utils/s-pl-1.md
+++ b/docs/_utils/s-pl-1.md
@@ -2,7 +2,7 @@
 title: s-pl-1
 category: utils
 util_type: padding
-order: 23
+order: 24
 ---
 <div class="s-pl-1">
   <code>s-pl-1</code>

--- a/docs/_utils/s-pl-2.md
+++ b/docs/_utils/s-pl-2.md
@@ -2,7 +2,7 @@
 title: s-pl-2
 category: utils
 util_type: padding
-order: 30
+order: 31
 ---
 <div class="s-pl-2">
   <code>s-pl-2</code>

--- a/docs/_utils/s-pl-3.md
+++ b/docs/_utils/s-pl-3.md
@@ -2,7 +2,7 @@
 title: s-pl-3
 category: utils
 util_type: padding
-order: 37
+order: 38
 ---
 <div class="s-pl-3">
   <code>s-pl-3</code>

--- a/docs/_utils/s-pl-4.md
+++ b/docs/_utils/s-pl-4.md
@@ -2,7 +2,7 @@
 title: s-pl-4
 category: utils
 util_type: padding
-order: 44
+order: 45
 ---
 <div class="s-pl-4">
   <code>s-pl-4</code>

--- a/docs/_utils/s-pl-5.md
+++ b/docs/_utils/s-pl-5.md
@@ -2,7 +2,7 @@
 title: s-pl-5
 category: utils
 util_type: padding
-order: 51
+order: 52
 ---
 <div class="s-pl-5">
   <code>s-pl-5</code>

--- a/docs/_utils/s-pr-0.md
+++ b/docs/_utils/s-pr-0.md
@@ -2,7 +2,7 @@
 title: s-pr-0
 category: utils
 util_type: padding
-order: 14
+order: 15
 ---
 <div class="s-pr-0">
   <code>s-pr-0</code>

--- a/docs/_utils/s-pr-1.md
+++ b/docs/_utils/s-pr-1.md
@@ -2,7 +2,7 @@
 title: s-pr-1
 category: utils
 util_type: padding
-order: 21
+order: 22
 ---
 <div class="s-pr-1">
   <code>s-pr-1</code>

--- a/docs/_utils/s-pr-2.md
+++ b/docs/_utils/s-pr-2.md
@@ -2,7 +2,7 @@
 title: s-pr-2
 category: utils
 util_type: padding
-order: 28
+order: 29
 ---
 <div class="s-pr-2">
   <code>s-pr-2</code>

--- a/docs/_utils/s-pr-3.md
+++ b/docs/_utils/s-pr-3.md
@@ -2,7 +2,7 @@
 title: s-pr-3
 category: utils
 util_type: padding
-order: 35
+order: 36
 ---
 <div class="s-pr-3">
   <code>s-pr-3</code>

--- a/docs/_utils/s-pr-4.md
+++ b/docs/_utils/s-pr-4.md
@@ -2,7 +2,7 @@
 title: s-pr-4
 category: utils
 util_type: padding
-order: 42
+order: 43
 ---
 <div class="s-pr-4">
   <code>s-pr-4</code>

--- a/docs/_utils/s-pr-5.md
+++ b/docs/_utils/s-pr-5.md
@@ -2,7 +2,7 @@
 title: s-pr-5
 category: utils
 util_type: padding
-order: 49
+order: 50
 ---
 <div class="s-pr-5">
   <code>s-pr-5</code>

--- a/docs/_utils/s-pt-0.md
+++ b/docs/_utils/s-pt-0.md
@@ -2,7 +2,7 @@
 title: s-pt-0
 category: utils
 util_type: padding
-order: 13
+order: 14
 ---
 <div class="s-pt-0">
   <code>s-pt-0</code>

--- a/docs/_utils/s-pt-1.md
+++ b/docs/_utils/s-pt-1.md
@@ -2,7 +2,7 @@
 title: s-pt-1
 category: utils
 util_type: padding
-order: 20
+order: 21
 ---
 <div class="s-pt-1">
   <code>s-pt-1</code>

--- a/docs/_utils/s-pt-2.md
+++ b/docs/_utils/s-pt-2.md
@@ -2,7 +2,7 @@
 title: s-pt-2
 category: utils
 util_type: padding
-order: 27
+order: 28
 ---
 <div class="s-pt-2">
   <code>s-pt-2</code>

--- a/docs/_utils/s-pt-3.md
+++ b/docs/_utils/s-pt-3.md
@@ -2,7 +2,7 @@
 title: s-pt-3
 category: utils
 util_type: padding
-order: 34
+order: 35
 ---
 <div class="s-pt-3">
   <code>s-pt-3</code>

--- a/docs/_utils/s-pt-4.md
+++ b/docs/_utils/s-pt-4.md
@@ -2,7 +2,7 @@
 title: s-pt-4
 category: utils
 util_type: padding
-order: 41
+order: 42
 ---
 <div class="s-pt-4">
   <code>s-pt-4</code>

--- a/docs/_utils/s-pt-5.md
+++ b/docs/_utils/s-pt-5.md
@@ -2,7 +2,7 @@
 title: s-pt-5
 category: utils
 util_type: padding
-order: 48
+order: 49
 ---
 <div class="s-pt-5">
   <code>s-pt-5</code>

--- a/docs/_utils/s-px-0.md
+++ b/docs/_utils/s-px-0.md
@@ -2,7 +2,7 @@
 title: s-px-0
 category: utils
 util_type: padding
-order: 11
+order: 12
 ---
 <div class="s-px-0">
   <code>s-px-0</code>

--- a/docs/_utils/s-px-1.md
+++ b/docs/_utils/s-px-1.md
@@ -2,7 +2,7 @@
 title: s-px-1
 category: utils
 util_type: padding
-order: 18
+order: 19
 ---
 <div class="s-px-1">
   <code>s-px-1</code>

--- a/docs/_utils/s-px-2.md
+++ b/docs/_utils/s-px-2.md
@@ -2,7 +2,7 @@
 title: s-px-2
 category: utils
 util_type: padding
-order: 25
+order: 26
 ---
 <div class="s-px-2">
   <code>s-px-2</code>

--- a/docs/_utils/s-px-3.md
+++ b/docs/_utils/s-px-3.md
@@ -2,7 +2,7 @@
 title: s-px-3
 category: utils
 util_type: padding
-order: 32
+order: 33
 ---
 <div class="s-px-3">
   <code>s-px-3</code>

--- a/docs/_utils/s-px-4.md
+++ b/docs/_utils/s-px-4.md
@@ -2,7 +2,7 @@
 title: s-px-4
 category: utils
 util_type: padding
-order: 39
+order: 40
 ---
 <div class="s-px-4">
   <code>s-px-4</code>

--- a/docs/_utils/s-px-5.md
+++ b/docs/_utils/s-px-5.md
@@ -2,7 +2,7 @@
 title: s-px-5
 category: utils
 util_type: padding
-order: 46
+order: 47
 ---
 <div class="s-px-5">
   <code>s-px-5</code>

--- a/docs/_utils/s-py-0.md
+++ b/docs/_utils/s-py-0.md
@@ -2,7 +2,7 @@
 title: s-py-0
 category: utils
 util_type: padding
-order: 12
+order: 13
 ---
 <div class="s-py-0">
   <code>s-py-0</code>

--- a/docs/_utils/s-py-1.md
+++ b/docs/_utils/s-py-1.md
@@ -2,7 +2,7 @@
 title: s-py-1
 category: utils
 util_type: padding
-order: 19
+order: 20
 ---
 <div class="s-py-1">
   <code>s-py-1</code>

--- a/docs/_utils/s-py-2.md
+++ b/docs/_utils/s-py-2.md
@@ -2,7 +2,7 @@
 title: s-py-2
 category: utils
 util_type: padding
-order: 26
+order: 27
 ---
 <div class="s-py-2">
   <code>s-py-2</code>

--- a/docs/_utils/s-py-3.md
+++ b/docs/_utils/s-py-3.md
@@ -2,7 +2,7 @@
 title: s-py-3
 category: utils
 util_type: padding
-order: 33
+order: 34
 ---
 <div class="s-py-3">
   <code>s-py-3</code>

--- a/docs/_utils/s-py-4.md
+++ b/docs/_utils/s-py-4.md
@@ -2,7 +2,7 @@
 title: s-py-4
 category: utils
 util_type: padding
-order: 40
+order: 41
 ---
 <div class="s-py-4">
   <code>s-py-4</code>

--- a/docs/_utils/s-py-5.md
+++ b/docs/_utils/s-py-5.md
@@ -2,7 +2,7 @@
 title: s-py-5
 category: utils
 util_type: padding
-order: 47
+order: 48
 ---
 <div class="s-py-5">
   <code>s-py-5</code>

--- a/utils.html
+++ b/utils.html
@@ -9,10 +9,6 @@ subnav:
   borders: Borders
 ---
 
-<h2 id="body" class="s-h2">Base Savile</h2>
-{% assign body_utils = site.utils | where: "util_type", "body" %}
-{% include utils-table.html utils=body_utils %}
-
 <h2 id="margins" class="s-h2">Margins</h2>
 {% assign margin_utils = site.utils | where: "util_type", "margin" %}
 {% include utils-table.html utils=margin_utils table_class="utils-table-margins" %}

--- a/utils.html
+++ b/utils.html
@@ -3,10 +3,15 @@ title: Utilities
 layout: default
 permalink: /utils/
 subnav:
+  body: Body
   margins: Margins
   padding: Padding
   borders: Borders
 ---
+
+<h2 id="body" class="s-h2">Base Savile</h2>
+{% assign body_utils = site.utils | where: "util_type", "body" %}
+{% include utils-table.html utils=body_utils %}
 
 <h2 id="margins" class="s-h2">Margins</h2>
 {% assign margin_utils = site.utils | where: "util_type", "margin" %}

--- a/utils.html
+++ b/utils.html
@@ -3,7 +3,6 @@ title: Utilities
 layout: default
 permalink: /utils/
 subnav:
-  body: Body
   margins: Margins
   padding: Padding
   borders: Borders


### PR DESCRIPTION
#### What does this PR do?

- Adds a `.s-content` class and draft of documentation for it
- Changes `.s-button` and variant classes to be able to override default link styling (as while implementing s-content in Turing.edu we had issues with that)

#### Where should the reviewer start?

- content.scss
- button.scss

#### How should this be manually tested?

If you want to test this out in action, you can do two things for a before/after effect. First run it locally, then:
- Run Turing.edu locally and hit http://localhost:4000/css/main.css instead of the current version
- Then you can pull down my most recent branch that I pushed the Turing.edu to see all the changes I made on top of pulling in this version. I had to remove some classes from elements, delete some color declarations in css, etc. to get Savile rules to take precedence. (Doing this is where I found the issue with the button and what led me to using !important. I had also tried adding button.s-button / a.s-button to get more specificity, but it was always the same specificity as the existing Turing rules and couldn't get it to override.)

#### Any background context you want to provide?


#### What are the relevant tickets?

https://3.basecamp.com/3494409/buckets/19192671/todolists/3663992610
https://3.basecamp.com/3494409/buckets/19192671/messages/3668606912

#### Screenshots (if appropriate)

<img width="1552" alt="Screen Shot 2021-04-23 at 7 55 17 AM" src="https://user-images.githubusercontent.com/25447342/115881876-6e78bf00-a409-11eb-80be-62173e00a0ee.png">

#### Any other deploy steps?