### PR TITLE
Spacing tokens update

### DIFF
--- a/css/design_system/index.scss
+++ b/css/design_system/index.scss
@@ -8,6 +8,7 @@
 @import "utils/spacing";
 @import "utils/borders";
 @import "utils/text";
+@import "utils/shadows";
 
 @import "elements/button";
 @import "elements/link";

--- a/css/design_system/tokens/shadows.scss
+++ b/css/design_system/tokens/shadows.scss
@@ -1,26 +1,23 @@
 :root {
   /**
-   * @title --s-shadow-s
+   * @title --s-shadow-sm
    * @category tokens
    * @token_type shadows
-   * @value 0 1px 3px hsla(0, 0%, 0.2)
-   * @description description
+   * @value 0 1px 3px var(--s-color-gray-600)
    */
-  --s-shadow-s: 0 1px 3px hsla(0, 0%, 0.2);
+  --s-shadow-sm: 0 1px 3px var(--s-color-gray-600);
   /**
-   * @title --s-shadow-m
+   * @title --s-shadow-md
    * @category tokens
    * @token_type shadows
-   * @value 0 4px 6px hsla(0, 0%, 0.2)
-   * @description description
+   * @value 0 4px 6px var(--s-color-gray-600)
    */
-  --s-shadow-m: 0 4px 6px hsla(0, 0%, 0.2);
+  --s-shadow-md: 0 4px 6px var(--s-color-gray-600);
   /**
-   * @title --s-shadow-l
+   * @title --s-shadow-lg
    * @category tokens
    * @token_type shadows
-   * @value 0 15px 35px hsla(0, 0%, 0.2)
-   * @description description
+   * @value 0 15px 35px var(--s-color-gray-600)
    */
-  --s-shadow-l: 0 15px 35px hsla(0, 0%, 0.2);
+  --s-shadow-lg: 0 15px 35px var(--s-color-gray-600);
 }

--- a/css/design_system/tokens/spacing.scss
+++ b/css/design_system/tokens/spacing.scss
@@ -1,114 +1,29 @@
+$spacing-options: (
+  "0": 0rem,
+  "1": 0.125rem,
+  "2": 0.25rem,
+  "3": 0.5rem,
+  "4": 0.75rem,
+  "5": 1rem,
+  "6": 1.25rem,
+  "7": 1.5rem,
+  "8": 1.75rem,
+  "9": 2rem,
+  "10": 2.5rem,
+  "11": 3rem,
+  "12": 3.5rem,
+  "13": 4rem
+);
+
 :root {
-  /**
-   * @title --s-space-0
+  @each $name, $size in $spacing-options {
+      /**
+   * @title --s-space-#{$name}
    * @category tokens
    * @token_type spacing
-   * @value 0rem
+   * @value #{$size}
    * @description description
    */
-  --s-space-0: 0rem;
-  /**
-   * @title --s-space-2
-   * @category tokens
-   * @token_type spacing
-   * @value 0.125rem
-   * @description description
-   */
-  --s-space-2: 0.125rem;
-  /**
-   * @title --s-space-4
-   * @category tokens
-   * @token_type spacing
-   * @value 0.25rem
-   * @description description
-   */
-  --s-space-4: 0.25rem;
-  /**
-   * @title --s-space-8
-   * @category tokens
-   * @token_type spacing
-   * @value 0.5rem
-   * @description description
-   */
-  --s-space-8: 0.5rem;
-  /**
-   * @title --s-space-12
-   * @category tokens
-   * @token_type spacing
-   * @value 0.75rem
-   * @description description
-   */
-  --s-space-12: 0.75rem;
-  /**
-   * @title --s-space-16
-   * @category tokens
-   * @token_type spacing
-   * @value 1rem
-   * @description description
-   */
-  --s-space-16: 1rem;
-  /**
-   * @title --s-space-20
-   * @category tokens
-   * @token_type spacing
-   * @value 1.25rem
-   * @description description
-   */
-  --s-space-20: 1.25rem;
-  /**
-   * @title --s-space-24
-   * @category tokens
-   * @token_type spacing
-   * @value 1.5rem
-   * @description description
-   */
-  --s-space-24: 1.5rem;
-  /**
-   * @title --s-space-28
-   * @category tokens
-   * @token_type spacing
-   * @value 1.75rem
-   * @description description
-   */
-  --s-space-28: 1.75rem;
-  /**
-   * @title --s-space-32
-   * @category tokens
-   * @token_type spacing
-   * @value 2rem
-   * @description description
-   */
-  --s-space-32: 2rem;
-  /**
-   * @title --s-space-40
-   * @category tokens
-   * @token_type spacing
-   * @value 2.5rem
-   * @description description
-   */
-  --s-space-40: 2.5rem;
-  /**
-   * @title --s-space-48
-   * @category tokens
-   * @token_type spacing
-   * @value 3rem
-   * @description description
-   */
-  --s-space-48: 3rem;
-  /**
-   * @title --s-space-56
-   * @category tokens
-   * @token_type spacing
-   * @value 3.5rem
-   * @description description
-   */
-  --s-space-56: 3.5rem;
-  /**
-   * @title --s-space-64
-   * @category tokens
-   * @token_type spacing
-   * @value 4rem
-   * @description description
-   */
-  --s-space-64: 4rem;
+  --s-space-#{$name}: #{$size};
+  }
 }

--- a/css/design_system/utils/borders.scss
+++ b/css/design_system/utils/borders.scss
@@ -17,10 +17,10 @@ $sides: border, border-top, border-right, border-bottom, border-left;
 
 $widths:
   "0" "--s-space-0",
-  "1" "--s-space-2",
-  "2" "--s-space-4",
-  "3" "--s-space-8",
-  "4" "--s-space-12";
+  "1" "--s-space-1",
+  "2" "--s-space-2",
+  "3" "--s-space-3",
+  "4" "--s-space-4";
 
 @each $width, $value in $widths {
   /**
@@ -40,8 +40,8 @@ $widths:
 
 $radii:
   "0" "var(--s-space-0)",
-  "1" "var(--s-space-4)",
-  "2" "var(--s-space-16)",
+  "1" "var(--s-space-2)",
+  "2" "var(--s-space-5)",
   "circle" "50%",
   "pill" "50rem";
 

--- a/css/design_system/utils/shadows.scss
+++ b/css/design_system/utils/shadows.scss
@@ -1,0 +1,24 @@
+$shadow-sizes: "sm", "md", "lg";
+
+@mixin docstring($class, $prop) {
+  /**
+   * @title #{$class}
+   * @category utils
+   * @util_type #{$prop}
+   *
+   * @example
+   * <div class="#{$class}">
+   *   <div class="s-p-2"></div>
+   * </div>
+   */
+}
+
+@each $shadow-size in $shadow-sizes {
+  $value: "--s-shadow-#{$shadow-size}";
+  $class-name: "s-shadow-#{$shadow-size}";
+
+  @include docstring($class-name, "shadow");
+  .#{$class-name} {
+    box-shadow: var(#{$value});
+  }
+}

--- a/css/design_system/utils/spacing.scss
+++ b/css/design_system/utils/spacing.scss
@@ -4,11 +4,11 @@ $space-types:
 
 $widths:
   "0" "--s-space-0",
-  "1" "--s-space-4",
-  "2" "--s-space-8",
-  "3" "--s-space-16",
-  "4" "--s-space-24",
-  "5" "--s-space-40";
+  "1" "--s-space-2",
+  "2" "--s-space-3",
+  "3" "--s-space-5",
+  "4" "--s-space-7",
+  "5" "--s-space-10";
 
 $sides:
   "t" "top",

--- a/css/doc_site_styling.scss
+++ b/css/doc_site_styling.scss
@@ -62,7 +62,7 @@ figure {
   justify-content: space-between;
   align-items: center;
   height: 60px;
-  padding: 0 var(--s-space-16);
+  padding: 0 var(--s-space-5);
   z-index: 2;
   position: relative;
 }
@@ -73,7 +73,7 @@ figure {
 
 .search-wrapper {
   align-self: center;
-  padding: var(--s-space-4) var(--s-space-32);
+  padding: var(--s-space-2) var(--s-space-9);
   display: flex;
 }
 
@@ -130,13 +130,13 @@ figure {
 .main-nav-item a,
 .sub-nav-item a {
   display: block;
-  padding: var(--s-space-16) var(--s-space-32) var(--s-space-12);
+  padding: var(--s-space-5) var(--s-space-9) var(--s-space-4);
   text-decoration: none;
   color: inherit;
 }
 
 .sub-nav-item a {
-  padding: var(--s-space-8) var(--s-space-48) var(--s-space-4);
+  padding: var(--s-space-3) var(--s-space-11) var(--s-space-2);
   font-weight: var(--s-font-weight-normal);
   text-transform: none;
 }
@@ -155,7 +155,7 @@ figure {
 /* ----------------------------------------- */
 .main {
   overflow-y: scroll;
-  padding: var(--s-space-64);
+  padding: var(--s-space-13);
   padding-top: 0;
 }
 
@@ -164,7 +164,7 @@ figure {
 }
 
 .main-content-container {
-  margin-top: var(--s-space-16);
+  margin-top: var(--s-space-5);
 }
 
 .table {
@@ -176,7 +176,7 @@ figure {
   width: 100%;
   border-spacing: 0;
   border: 1px solid var(--s-color-gray-200);
-  margin-bottom: var(--s-space-48);
+  margin-bottom: var(--s-space-11);
 }
 
 .table-head-row {
@@ -214,7 +214,7 @@ figure {
 // TOKEN Specific Tables
 .token-title-cell {
   width: auto;
-  padding: var(--s-space-16);
+  padding: var(--s-space-5);
   overflow-wrap: break-word;
   border-right: 1px solid var(--s-color-gray-200);
 
@@ -224,12 +224,12 @@ figure {
 }
 
 .token-description-cell {
-  margin-top: var(--s-space-8);
+  margin-top: var(--s-space-3);
 }
 
 .token-value-cell {
   width: 30%;
-  padding: var(--s-space-16);
+  padding: var(--s-space-5);
   border-right: 1px solid var(--s-color-gray-200);
 }
 
@@ -324,7 +324,7 @@ figure {
 .footer-copyright-wrapper {
   display: flex;
   background-color: var(--s-color-gray-800);
-  padding: 0 var(--s-space-16);
+  padding: 0 var(--s-space-5);
 }
 
 .footer-copyright-wrapper p {
@@ -349,7 +349,7 @@ figure {
   width: 5rem;
   height: 5rem;
   background-color: var(--s-color-gray-300);
-  margin: var(--s-space-16) auto;
+  margin: var(--s-space-5) auto;
 }
 
 .utils-table-borders .s-border-radius-pill {

--- a/docs/_components/Primary Nav.md
+++ b/docs/_components/Primary Nav.md
@@ -3,7 +3,7 @@ title: Primary Nav
 category: components
 status: early draft
 description: Navigation component w/ primary and secondary variants.
-order: 130
+order: 133
 ---
 <nav class="nav nav-primary">
   <ul>

--- a/docs/_content/Savile Content.md
+++ b/docs/_content/Savile Content.md
@@ -4,7 +4,7 @@ category: content
 description: Our base content styles. If this class is added to the body tag (or any
   container tag), all its children will receive this styling.
 value: ".s-content"
-order: 129
+order: 132
 ---
 <section class="s-content">
  <p>Sample paragraph</p>

--- a/docs/_elements/Base Button.md
+++ b/docs/_elements/Base Button.md
@@ -6,6 +6,6 @@ status: draft
 value: s-button
 description: Our base button styles. Any other button class can be used in addition
   to this, to get the desired variant.
-order: 123
+order: 126
 ---
 <button class="s-button">Base Button</button>

--- a/docs/_elements/Link.md
+++ b/docs/_elements/Link.md
@@ -5,6 +5,6 @@ element_type: link
 status: draft
 value: s-link
 description: Styles for a link that is embedded in the default paragraph text.
-order: 127
+order: 130
 ---
 <a class="s-link">contact our team</a>

--- a/docs/_elements/Paragraph.md
+++ b/docs/_elements/Paragraph.md
@@ -6,6 +6,6 @@ status: draft
 value: s-p
 description: A paragraph element with built-in size, color, and font-family. To be
   used with a white background.
-order: 128
+order: 131
 ---
 <p class="s-p">The default paragraph text is 16px and is intended for text on a white background.</p>

--- a/docs/_elements/Primary Button.md
+++ b/docs/_elements/Primary Button.md
@@ -6,6 +6,6 @@ status: draft
 value: s-button-primary
 description: Our primary call-to-action button for specific actions - apply, register
   for Try Coding, subscribe to newsletter, etc.
-order: 124
+order: 127
 ---
 <button class="s-button s-button-primary">Primary</button>

--- a/docs/_elements/Primary Inverse Button.md
+++ b/docs/_elements/Primary Inverse Button.md
@@ -6,6 +6,6 @@ status: draft
 value: s-button-primary-inverse
 description: Our primary call-to-action button, with inverse colors. These are usually
   used for buttons that lead user to more info.
-order: 125
+order: 128
 ---
 <button class="s-button s-button-primary-inverse">Primary Inverse</button>

--- a/docs/_elements/Secondary Button.md
+++ b/docs/_elements/Secondary Button.md
@@ -6,6 +6,6 @@ status: draft
 value: s-button-secondary
 description: Our secondary call-to-action button for specific actions - apply, register
   for Try Coding, subscribe to newsletter, etc.
-order: 126
+order: 129
 ---
 <button class="s-button s-button-secondary">Secondary</button>

--- a/docs/_tokens/--s-shadow-l.md
+++ b/docs/_tokens/--s-shadow-l.md
@@ -1,8 +1,0 @@
----
-title: "--s-shadow-l"
-category: tokens
-token_type: shadows
-value: 0 15px 35px hsla(0, 0%, 0.2)
-description: description
-order: 3
----

--- a/docs/_tokens/--s-shadow-lg.md
+++ b/docs/_tokens/--s-shadow-lg.md
@@ -1,0 +1,7 @@
+---
+title: "--s-shadow-lg"
+category: tokens
+token_type: shadows
+value: 0 15px 35px var(--s-color-gray-600)
+order: 3
+---

--- a/docs/_tokens/--s-shadow-m.md
+++ b/docs/_tokens/--s-shadow-m.md
@@ -1,8 +1,0 @@
----
-title: "--s-shadow-m"
-category: tokens
-token_type: shadows
-value: 0 4px 6px hsla(0, 0%, 0.2)
-description: description
-order: 2
----

--- a/docs/_tokens/--s-shadow-md.md
+++ b/docs/_tokens/--s-shadow-md.md
@@ -1,0 +1,7 @@
+---
+title: "--s-shadow-md"
+category: tokens
+token_type: shadows
+value: 0 4px 6px var(--s-color-gray-600)
+order: 2
+---

--- a/docs/_tokens/--s-shadow-s.md
+++ b/docs/_tokens/--s-shadow-s.md
@@ -1,8 +1,0 @@
----
-title: "--s-shadow-s"
-category: tokens
-token_type: shadows
-value: 0 1px 3px hsla(0, 0%, 0.2)
-description: description
-order: 1
----

--- a/docs/_tokens/--s-shadow-sm.md
+++ b/docs/_tokens/--s-shadow-sm.md
@@ -1,0 +1,7 @@
+---
+title: "--s-shadow-sm"
+category: tokens
+token_type: shadows
+value: 0 1px 3px var(--s-color-gray-600)
+order: 1
+---

--- a/docs/_tokens/--s-space-1.md
+++ b/docs/_tokens/--s-space-1.md
@@ -1,8 +1,8 @@
 ---
-title: "--s-space-40"
+title: "--s-space-1"
 category: tokens
 token_type: spacing
-value: 2.5rem
+value: 0.125rem
 description: description
-order: 11
+order: 2
 ---

--- a/docs/_tokens/--s-space-10.md
+++ b/docs/_tokens/--s-space-10.md
@@ -1,8 +1,8 @@
 ---
-title: "--s-space-32"
+title: "--s-space-10"
 category: tokens
 token_type: spacing
-value: 2rem
+value: 2.5rem
 description: description
-order: 10
+order: 11
 ---

--- a/docs/_tokens/--s-space-11.md
+++ b/docs/_tokens/--s-space-11.md
@@ -1,8 +1,8 @@
 ---
-title: "--s-space-64"
+title: "--s-space-11"
 category: tokens
 token_type: spacing
-value: 4rem
+value: 3rem
 description: description
-order: 14
+order: 12
 ---

--- a/docs/_tokens/--s-space-12.md
+++ b/docs/_tokens/--s-space-12.md
@@ -2,7 +2,7 @@
 title: "--s-space-12"
 category: tokens
 token_type: spacing
-value: 0.75rem
+value: 3.5rem
 description: description
-order: 5
+order: 13
 ---

--- a/docs/_tokens/--s-space-13.md
+++ b/docs/_tokens/--s-space-13.md
@@ -1,8 +1,8 @@
 ---
-title: "--s-space-56"
+title: "--s-space-13"
 category: tokens
 token_type: spacing
-value: 3.5rem
+value: 4rem
 description: description
-order: 13
+order: 14
 ---

--- a/docs/_tokens/--s-space-2.md
+++ b/docs/_tokens/--s-space-2.md
@@ -2,7 +2,7 @@
 title: "--s-space-2"
 category: tokens
 token_type: spacing
-value: 0.125rem
+value: 0.25rem
 description: description
-order: 2
+order: 3
 ---

--- a/docs/_tokens/--s-space-3.md
+++ b/docs/_tokens/--s-space-3.md
@@ -1,8 +1,8 @@
 ---
-title: "--s-space-48"
+title: "--s-space-3"
 category: tokens
 token_type: spacing
-value: 3rem
+value: 0.5rem
 description: description
-order: 12
+order: 4
 ---

--- a/docs/_tokens/--s-space-4.md
+++ b/docs/_tokens/--s-space-4.md
@@ -2,7 +2,7 @@
 title: "--s-space-4"
 category: tokens
 token_type: spacing
-value: 0.25rem
+value: 0.75rem
 description: description
-order: 3
+order: 5
 ---

--- a/docs/_tokens/--s-space-5.md
+++ b/docs/_tokens/--s-space-5.md
@@ -1,8 +1,8 @@
 ---
-title: "--s-space-20"
+title: "--s-space-5"
 category: tokens
 token_type: spacing
-value: 1.25rem
+value: 1rem
 description: description
-order: 7
+order: 6
 ---

--- a/docs/_tokens/--s-space-6.md
+++ b/docs/_tokens/--s-space-6.md
@@ -1,8 +1,8 @@
 ---
-title: "--s-space-24"
+title: "--s-space-6"
 category: tokens
 token_type: spacing
-value: 1.5rem
+value: 1.25rem
 description: description
-order: 8
+order: 7
 ---

--- a/docs/_tokens/--s-space-7.md
+++ b/docs/_tokens/--s-space-7.md
@@ -1,8 +1,8 @@
 ---
-title: "--s-space-16"
+title: "--s-space-7"
 category: tokens
 token_type: spacing
-value: 1rem
+value: 1.5rem
 description: description
-order: 6
+order: 8
 ---

--- a/docs/_tokens/--s-space-8.md
+++ b/docs/_tokens/--s-space-8.md
@@ -2,7 +2,7 @@
 title: "--s-space-8"
 category: tokens
 token_type: spacing
-value: 0.5rem
+value: 1.75rem
 description: description
-order: 4
+order: 9
 ---

--- a/docs/_tokens/--s-space-9.md
+++ b/docs/_tokens/--s-space-9.md
@@ -1,8 +1,8 @@
 ---
-title: "--s-space-28"
+title: "--s-space-9"
 category: tokens
 token_type: spacing
-value: 1.75rem
+value: 2rem
 description: description
-order: 9
+order: 10
 ---

--- a/docs/_utils/s-shadow-lg.md
+++ b/docs/_utils/s-shadow-lg.md
@@ -1,0 +1,9 @@
+---
+title: s-shadow-lg
+category: utils
+util_type: shadow
+order: 125
+---
+<div class="s-shadow-lg">
+  <div class="s-p-2"></div>
+</div>

--- a/docs/_utils/s-shadow-md.md
+++ b/docs/_utils/s-shadow-md.md
@@ -1,0 +1,9 @@
+---
+title: s-shadow-md
+category: utils
+util_type: shadow
+order: 124
+---
+<div class="s-shadow-md">
+  <div class="s-p-2"></div>
+</div>

--- a/docs/_utils/s-shadow-sm.md
+++ b/docs/_utils/s-shadow-sm.md
@@ -1,0 +1,9 @@
+---
+title: s-shadow-sm
+category: utils
+util_type: shadow
+order: 123
+---
+<div class="s-shadow-sm">
+  <div class="s-p-2"></div>
+</div>

--- a/utils.html
+++ b/utils.html
@@ -10,6 +10,7 @@ subnav:
   margins: Margins
   padding: Padding
   borders: Borders
+  shadows: Shadows
 ---
 
 <h2 id="font-weight" class="s-h2 s-mt-5">Font Weight</h2>
@@ -44,3 +45,7 @@ subnav:
   {% assign utils = border_utils | where: "border_group", border_group %}
   {% include utils-table.html utils=utils table_class="utils-table-borders" %}
 {% endfor %}
+
+<h2 id="shadows" class="s-h2 s-mt-5">Shadows</h2>
+{% assign shadow_utils = site.utils | where: "util_type", "shadow" %}
+{% include utils-table.html utils=shadow_utils table_class="utils-table-padding" %}


### PR DESCRIPTION
#### What does this PR do?

- Updates spacing tokens to use a 0, 1, 2, 3, etc. systems rather than the 0, 2, 4, 8, 16 it was previously using. 
- Refactored the spacing tokens to utilize an @each and make file shorter, less repetition

#### Where should the reviewer start?

- `tokens/spacing.scss`

#### How should this be manually tested?

#### Any background context you want to provide?

- Spacing tokens were being used by several utils and in doc site styling itself, so I went back through and changed each to the use what is now the correct variable. It made me nervous but I believe I got them all.

#### What are the relevant tickets?

https://3.basecamp.com/3494409/buckets/19192671/todos/3455119332 

#### Screenshots (if appropriate)

<img width="1552" alt="Screen Shot 2021-05-13 at 10 30 56 AM" src="https://user-images.githubusercontent.com/25447342/118156346-7c04e180-b3d6-11eb-955c-0734d4808528.png">
