### PR TITLE
Adjust syntax highlighting colors for WCAG AA compliance

### DIFF
--- a/css/syntax.css
+++ b/css/syntax.css
@@ -25,7 +25,7 @@ pre {
 .highlight .k { color: #8959a8 } /* Keyword */
 .highlight .l { color: #f5871f } /* Literal */
 .highlight .n { color: #4d4d4c } /* Name */
-.highlight .o { color: #3e999f } /* Operator */
+.highlight .o { color: #337c84 } /* Operator - changed from original #3e999f for accessibility */
 .highlight .p { color: #4d4d4c } /* Punctuation */
 .highlight .cm { color: #8e908c } /* Comment.Multiline */
 .highlight .cp { color: #8e908c } /* Comment.Preproc */
@@ -34,24 +34,24 @@ pre {
 .highlight .gd { color: #c82829 } /* Generic.Deleted */
 .highlight .ge { font-style: italic } /* Generic.Emph */
 .highlight .gh { color: #4d4d4c; font-weight: bold } /* Generic.Heading */
-.highlight .gi { color: #718c00 } /* Generic.Inserted */
+.highlight .gi { color: #5e7500 } /* Generic.Inserted - changed from original #5e7500 for accessibility */
 .highlight .gp { color: #8e908c; font-weight: bold } /* Generic.Prompt */
 .highlight .gs { font-weight: bold } /* Generic.Strong */
-.highlight .gu { color: #3e999f; font-weight: bold } /* Generic.Subheading */
+.highlight .gu { color: #337c84; font-weight: bold } /* Generic.Subheading */
 .highlight .kc { color: #8959a8 } /* Keyword.Constant */
 .highlight .kd { color: #8959a8 } /* Keyword.Declaration */
-.highlight .kn { color: #3e999f } /* Keyword.Namespace */
+.highlight .kn { color: #337c84 } /* Keyword.Namespace */
 .highlight .kp { color: #8959a8 } /* Keyword.Pseudo */
 .highlight .kr { color: #8959a8 } /* Keyword.Reserved */
 .highlight .kt { color: #eab700 } /* Keyword.Type */
-.highlight .ld { color: #718c00 } /* Literal.Date */
+.highlight .ld { color: #5e7500 } /* Literal.Date */
 .highlight .m { color: #f5871f } /* Literal.Number */
-.highlight .s { color: #718c00 } /* Literal.String */
+.highlight .s { color: #5e7500 } /* Literal.String */
 .highlight .na { color: #4271ae } /* Name.Attribute */
 .highlight .nb { color: #4d4d4c } /* Name.Builtin */
 .highlight .nc { color: #eab700 } /* Name.Class */
 .highlight .no { color: #c82829 } /* Name.Constant */
-.highlight .nd { color: #3e999f } /* Name.Decorator */
+.highlight .nd { color: #337c84 } /* Name.Decorator */
 .highlight .ni { color: #4d4d4c } /* Name.Entity */
 .highlight .ne { color: #c82829 } /* Name.Exception */
 .highlight .nf { color: #4271ae } /* Name.Function */
@@ -59,25 +59,25 @@ pre {
 .highlight .nn { color: #eab700 } /* Name.Namespace */
 .highlight .nx { color: #4271ae } /* Name.Other */
 .highlight .py { color: #4d4d4c } /* Name.Property */
-.highlight .nt { color: #3e999f } /* Name.Tag */
+.highlight .nt { color: #337c84 } /* Name.Tag */
 .highlight .nv { color: #c82829 } /* Name.Variable */
-.highlight .ow { color: #3e999f } /* Operator.Word */
+.highlight .ow { color: #337c84 } /* Operator.Word */
 .highlight .w { color: #4d4d4c } /* Text.Whitespace */
 .highlight .mf { color: #f5871f } /* Literal.Number.Float */
 .highlight .mh { color: #f5871f } /* Literal.Number.Hex */
 .highlight .mi { color: #f5871f } /* Literal.Number.Integer */
 .highlight .mo { color: #f5871f } /* Literal.Number.Oct */
-.highlight .sb { color: #718c00 } /* Literal.String.Backtick */
+.highlight .sb { color: #5e7500 } /* Literal.String.Backtick */
 .highlight .sc { color: #4d4d4c } /* Literal.String.Char */
 .highlight .sd { color: #8e908c } /* Literal.String.Doc */
-.highlight .s2 { color: #718c00 } /* Literal.String.Double */
+.highlight .s2 { color: #5e7500 } /* Literal.String.Double */
 .highlight .se { color: #f5871f } /* Literal.String.Escape */
-.highlight .sh { color: #718c00 } /* Literal.String.Heredoc */
+.highlight .sh { color: #5e7500 } /* Literal.String.Heredoc */
 .highlight .si { color: #f5871f } /* Literal.String.Interpol */
-.highlight .sx { color: #718c00 } /* Literal.String.Other */
-.highlight .sr { color: #718c00 } /* Literal.String.Regex */
-.highlight .s1 { color: #718c00 } /* Literal.String.Single */
-.highlight .ss { color: #718c00 } /* Literal.String.Symbol */
+.highlight .sx { color: #5e7500 } /* Literal.String.Other */
+.highlight .sr { color: #5e7500 } /* Literal.String.Regex */
+.highlight .s1 { color: #5e7500 } /* Literal.String.Single */
+.highlight .ss { color: #5e7500 } /* Literal.String.Symbol */
 .highlight .bp { color: #4d4d4c } /* Name.Builtin.Pseudo */
 .highlight .vc { color: #c82829 } /* Name.Variable.Class */
 .highlight .vg { color: #c82829 } /* Name.Variable.Global */

--- a/css/syntax.css
+++ b/css/syntax.css
@@ -1,5 +1,8 @@
 /* Syntax highlighting rules taken from FE curriculum site - https://github.com/turingschool/front-end-curriculum/blob/gh-pages/_sass/syntax.scss */
-/* with exception of background color to use a Savile grey, and removing border around code snippets */
+/* with exception of:
+  /* background color changed to use a Savile grey
+  /* removed border around code snippets
+  /* changed two colors to be dark enough for a sufficient WCAG AA contrast on a light gray background (specific colors are noted below the first time they are used) */
 
 code {
   font-family: monospace;


### PR DESCRIPTION
#### What does this PR do?
Adjusts two colors in the `syntax.css` file so that when code snippets are on a light gray background, they have sufficient contrast.

#### Where should the reviewer start?
- `syntax.css` file
- Screenshots

#### How should this be manually tested?
n/a

#### Any background context you want to provide?
Once we started putting code snippets on gray backgrounds (when the rows of a table alternate colors) we noticed contrast issues. This is also the code for multi-line code snippets.

#### What are the relevant tickets?
#41 

#### Screenshots (if appropriate)
Before (score was 98 on /utils and had warnings for each time the teal and green were used):
<img width="1552" alt="Screen Shot 2021-05-25 at 11 04 45 AM" src="https://user-images.githubusercontent.com/25447342/119539848-eceab880-bd49-11eb-9fcf-b2ef120634e6.png">

After:
<img width="1552" alt="Screen Shot 2021-05-25 at 11 04 11 AM" src="https://user-images.githubusercontent.com/25447342/119539880-f8d67a80-bd49-11eb-8adf-b2e7e4aee915.png">