### PR TITLE
Add bin/percy script for generating snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Please follow Turing's shared [How to Contribute](https://www.notion.so/turingsc
 
 Anything that is merged into the `main` branch will not be immediately available on the `latest` version (or any other version). To release a new version and publish the latest changes, make sure to follow the guidance outlined in [contributing.md](./contributing.md).
 
+### Generating Snapshots for your Pull Request
+
+We use [Percy](https://percy.io/) to generate visual diffs of changes introduced. This helps ensure that every pull request includes a clear summary of how the code changes affected the site UI.
+
+When you are ready to submit your PR for review, please create a Percy build by running the script `$ ./bin/percy`. You will need the `PERCY_TOKEN` environment variable to be set - this can be found by logging into Percy (account info is in the shared Turing 1password).
+
 ## How To: Add a Token, Element or Component
 
 The workflow to add a token, element or component to Savile is as follows:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 The Turing School of Software and Design's Design System. The site provides an everything-in-one-place guide to our style guide and available utils and class names for pre-built components that conform to the style guide. The design system itself is consumed by all* sites and apps in the Turing suite via CDN.
 
-[Project managed on Basecamp.](https://3.basecamp.com/3494409/projects/19192671)
-
 More information about internal engineering @ Turing is available on [Turing's Engineering Wiki](https://www.notion.so/Engineering-Wiki-29887c546265429db78560f47525d9f2). Look here to find documentation on topics like our [Guiding Principles,](https://www.notion.so/Guiding-Principles-57dc38f1b6454645bf23b252bc22b440) [How to Contribute](https://www.notion.so/How-to-Contribute-1b88e17f755c491989e4b2bc84db93c7), and [Project Standards](https://www.notion.so/Project-Standards-889a4f2b26b04dc091039f209f823c3c).
 
 ## Table of Contents

--- a/bin/percy
+++ b/bin/percy
@@ -5,4 +5,17 @@
 # Requires that the PERCY_TOKEN env variable be set.
 # https://docs.percy.io/docs/jekyll
 
+if [[ -z "${PERCY_TOKEN}" ]]; then
+  echo "PERCY_TOKEN has not been set. Please run this script with this env variable."
+  echo "  Example:"
+  echo "  $ PERCY_TOKEN=abcd ./bin/percy"
+  exit 1
+fi
+
+# First generate a fresh build of the site
+echo "Running 'bundle exec jekyll build'..."
+bundle exec jekyll build
+
+# Then capture the snapshots for Percy
+echo "Running 'npx percy snapshot _site/'..."
 npx percy snapshot _site/

--- a/bin/percy
+++ b/bin/percy
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Generate snapshots for Percy
+#
+# Requires that the PERCY_TOKEN env variable be set.
+# https://docs.percy.io/docs/jekyll
+
+npx percy snapshot _site/


### PR DESCRIPTION
#### What does this PR do?
Adds a helper script to allow us to generate snapshots for visual diff testing using Percy.io.

Now when a PR is ready for review, we can run `$ ./bin/percy` and it will build the site and generate snapshots for us.

#### Where should the reviewer start?
README

#### How should this be manually tested?
For an open PR, try running `./bin/percy` and check out the snapshots created!

#### Any background context you want to provide?


#### What are the relevant tickets?
In [Notion](https://www.notion.so/turingschool/2105-1-2e599574d49d4fa6a400fd57f29897cc?p=e6dfd743f96f44918d0ecf716268ad42).

#### Screenshots (if appropriate)
![Screen Shot 2021-06-04 at 7 31 32 AM](https://user-images.githubusercontent.com/709100/120809209-11dbea00-c507-11eb-8cae-d13f5f81bacb.png)


#### Any other deploy steps?
Nope